### PR TITLE
team API, post API 작성(미완)

### DIFF
--- a/football_love/src/main/java/com/deu/football_love/controller/BoardController.java
+++ b/football_love/src/main/java/com/deu/football_love/controller/BoardController.java
@@ -15,13 +15,13 @@ public class BoardController {
 
     private final BoardServiceImpl boardService;
     @PostMapping("/add")
-    public ResponseEntity add(String boardName, BoardType boardType, Long teamId)
+    public ResponseEntity add(String boardName, BoardType boardType, String teamName)
     {
        if(boardName == null || boardType == null || (boardType != BoardType.GENERAL
-               && boardType!= BoardType.NOTICE && boardType != BoardType.PHOTO)  || teamId == null)
+               && boardType!= BoardType.NOTICE && boardType != BoardType.PHOTO)  || teamName == null)
            return new ResponseEntity(HttpStatus.BAD_REQUEST);
        Board board = new Board(boardName,boardType);
-       boardService.newBoard(board,teamId);
+       boardService.newBoard(board,teamName);
        return new ResponseEntity(HttpStatus.OK);
     }
 

--- a/football_love/src/main/java/com/deu/football_love/controller/MemberController.java
+++ b/football_love/src/main/java/com/deu/football_love/controller/MemberController.java
@@ -87,7 +87,7 @@ public class MemberController {
 	}
 
 	@ApiOperation(value = "회원탈퇴 요청", notes = "id와 회원을 확인해 회원탈퇴 요청을 한다.")
-	@PutMapping("/{id}")
+	@PutMapping("/withdrawals/{id}")
 	public ResponseEntity withdrawMember(@PathVariable String id, HttpSession session) {
 		Member sessionMember = (Member) session.getAttribute(SESSION_MEMBER);
 		if (sessionMember == null) {

--- a/football_love/src/main/java/com/deu/football_love/controller/TeamController.java
+++ b/football_love/src/main/java/com/deu/football_love/controller/TeamController.java
@@ -1,24 +1,21 @@
 package com.deu.football_love.controller;
 
-import com.deu.football_love.domain.Member;
-import com.deu.football_love.domain.Team;
-import com.deu.football_love.domain.TeamAdmin;
-import com.deu.football_love.domain.TeamMember;
-import com.deu.football_love.repository.MemberRepository;
-import com.deu.football_love.repository.TeamRepository;
+import com.deu.football_love.domain.*;
+import com.deu.football_love.domain.type.AuthorityType;
+import com.deu.football_love.dto.CreateTeamRequest;
+import com.deu.football_love.dto.JoinApplyRequest;
+import com.deu.football_love.dto.TeamDto;
 import com.deu.football_love.service.MemberService;
 import com.deu.football_love.service.TeamService;
+import io.swagger.models.Response;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
-import java.util.Map;
+import java.util.List;
 
 @RequestMapping("/team")
 @RequiredArgsConstructor
@@ -26,18 +23,32 @@ import java.util.Map;
 @Slf4j
 public class TeamController {
 
-    private final MemberRepository memberRepository;
-    private final TeamRepository teamRepository;
-
     private final MemberService memberService;
     private final TeamService teamService;
-    @PostMapping
-    public ResponseEntity add(@RequestBody Map<String,String> params)
+
+    @GetMapping("/{teamName}")
+    public ResponseEntity get(@PathVariable String teamName){
+        Team findTeam = teamService.findTeam(teamName);
+        return ResponseEntity.ok().body(teamService.getTeamInfo(findTeam));
+    }
+
+    @PostMapping("/duplication/{teamName}")
+    public ResponseEntity duplicationCheck(@PathVariable String teamName)
     {
-        Member findMember = memberService.findMember(params.get("creator"));
+        Team findTeam = teamService.findTeam(teamName);
+        if(findTeam == null)
+            return new ResponseEntity(HttpStatus.OK);
+        else
+            return new ResponseEntity(HttpStatus.CONFLICT);
+    }
+
+    @PostMapping
+    public ResponseEntity add(@RequestBody CreateTeamRequest request)
+    {
+        Member findMember = memberService.findMember("");
         Team newTeam = new Team();
         TeamAdmin teamAdmin = new TeamAdmin();
-        newTeam.setName(params.get("teamName"));
+        newTeam.setName(request.getName());
         newTeam.setCreateDate(LocalDate.now());
         teamAdmin.setTeam(newTeam);
         teamAdmin.setMember(findMember);
@@ -45,20 +56,90 @@ public class TeamController {
         return new ResponseEntity(HttpStatus.OK);
     }
 
-    @PostMapping("/join")
-    public ResponseEntity join(@RequestBody Map<String,String> params)
+    /**
+     * 팀 가입 신청
+     * 세션 구현이 안되어있어서 세션 구현 후 수정 해야함
+     **/
+    @PostMapping("/join_requestion/{teamName}")
+    public ResponseEntity apply(@PathVariable String teamName, JoinApplyRequest request)
     {
-        Member findMember = memberService.findMember(params.get("id"));
-        Team team = teamService.findTeam(params.get("teamName"));
+        /**
+         * findMember는 세션의 로그인 회원 정보
+         */
+        Member findMember = memberService.findMember("");
+        Team team = teamService.findTeam(teamName);
+        String message = request.getMessage();
 
-        if(team == null || findMember == null)
-        {
+        if(team == null || findMember == null || message == null)
             return new ResponseEntity(HttpStatus.BAD_REQUEST);
+        ApplicationJoinTeam application = new ApplicationJoinTeam(team, findMember, message);
+
+        teamService.applyToTeam(application);
+        return new ResponseEntity(HttpStatus.OK);
+    }
+
+    /**
+     *  팀 가입 수락
+     *  세션 구현 후 team의 admin인지 확인하고 처리해야함
+     */
+    @PostMapping("/join_acception/{teamName}/{memberId]")
+    public ResponseEntity join(@PathVariable String teamName, @PathVariable String memberId)
+    {
+        Member findMember = memberService.findMember(memberId);
+        Team findTeam = teamService.findTeam(teamName);
+
+        /**
+         * 어드민이 아니면 401 오류 발생
+         */
+        if(findTeam == null || findMember == null)
+            return new ResponseEntity(HttpStatus.BAD_REQUEST);
+        ApplicationJoinTeam findApplication = teamService.findApplication(findTeam.getName(), findMember.getId());
+        if (findApplication == null)
+            return new ResponseEntity(HttpStatus.BAD_REQUEST);
+        TeamMember newTeamMember = new TeamMember(findTeam, findMember, AuthorityType.MEMBER);
+        teamService.acceptApplication(findApplication, newTeamMember);
+
+        return new ResponseEntity(HttpStatus.OK);
+    }
+
+    /**
+     * 팀 멤버 탈퇴
+     * 
+     */
+    @DeleteMapping("/{teamName}/member/{memberId}")
+    public ResponseEntity withdrawal(@PathVariable String teamName, @PathVariable String memberId)
+    {
+
+        Member findMember = memberService.findMember(memberId); // 추방될 멤버
+        Member loginedMember = memberService.findMember("");// 현재 계정 정보
+        Team findTeam = teamService.findTeam(teamName);
+
+        if(findTeam == null || findMember == null || teamService.authorityCheck(teamName, memberId) != AuthorityType.MEMBER)
+            return new ResponseEntity(HttpStatus.BAD_REQUEST);
+
+        if (!memberId.equals(loginedMember.getId())) // 관리자에 의해 강퇴
+        {
+            AuthorityType authorityType = teamService.authorityCheck(teamName, loginedMember.getId());
+            if (authorityType != AuthorityType.ADMIN)
+                return new ResponseEntity(HttpStatus.UNAUTHORIZED);
         }
-        TeamMember newTeamMember = new TeamMember();
-        newTeamMember.setMember(findMember);
-        newTeamMember.setTeam(team);
-        teamService.joinTeam(newTeamMember);
+        teamService.withdrawal(findTeam.getName(), memberId);
+        return new ResponseEntity(HttpStatus.OK);
+    }
+
+    /**
+     * 팀 해체
+     * 
+     */
+    @DeleteMapping("/{teamName}")
+    public ResponseEntity disbandment(@PathVariable String teamName)
+    {
+        Member loginedMember = memberService.findMember("");
+        Team findTeam = teamService.findTeam(teamName);
+        List<TeamMember> teamMember = teamService.findTeamMember(teamName, loginedMember.getId());
+        if (teamMember.size() == 0 || teamMember.get(0).getAuthority() == AuthorityType.MEMBER)
+            return new ResponseEntity(HttpStatus.UNAUTHORIZED);
+        teamService.disbandmentTeam(findTeam);
         return new ResponseEntity(HttpStatus.OK);
     }
 }

--- a/football_love/src/main/java/com/deu/football_love/domain/ApplicationJoinTeam.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/ApplicationJoinTeam.java
@@ -1,0 +1,33 @@
+package com.deu.football_love.domain;
+
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+public class ApplicationJoinTeam {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_name")
+    private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private String message;
+
+    public ApplicationJoinTeam(Team team, Member member, String message) {
+        this.team = team;
+        this.member = member;
+        this.message = message;
+    }
+
+    protected ApplicationJoinTeam() {
+
+    }
+}

--- a/football_love/src/main/java/com/deu/football_love/domain/Board.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/Board.java
@@ -28,7 +28,7 @@ public class Board {
     private List<Post> posts = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "team_id", referencedColumnName ="team_id")
+    @JoinColumn(name = "team_name", referencedColumnName ="team_name")
     private Team team;
 
     public Board(String boardName, BoardType boardType) {

--- a/football_love/src/main/java/com/deu/football_love/domain/MatchApplication.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/MatchApplication.java
@@ -11,7 +11,7 @@ public class MatchApplication {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "team_id")
+    @JoinColumn(name = "team_name")
     private Team team;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/football_love/src/main/java/com/deu/football_love/domain/Matches.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/Matches.java
@@ -11,7 +11,7 @@ public class Matches {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "team_id", referencedColumnName = "team_id")
+    @JoinColumn(name = "team_name", referencedColumnName = "team_name")
     private Team team;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/football_love/src/main/java/com/deu/football_love/domain/Member.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/Member.java
@@ -55,6 +55,9 @@ public class Member {
 	@OneToMany(mappedBy = "member")
 	private List<ParticipationMember> participationMembers = new ArrayList<>();
 
+	@OneToMany(mappedBy = "member")
+	private List<ApplicationJoinTeam> applicationJoinTeams = new ArrayList<>();
+
 	@OneToOne(mappedBy = "member")
 	private WithdrawalMember withdrawalMember;
   

--- a/football_love/src/main/java/com/deu/football_love/domain/ParticipationMember.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/ParticipationMember.java
@@ -15,7 +15,7 @@ public class ParticipationMember {
     private Matches match;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "team_id")
+    @JoinColumn(name = "team_name")
     private Team team;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/football_love/src/main/java/com/deu/football_love/domain/Team.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/Team.java
@@ -14,10 +14,6 @@ import java.util.List;
 public class Team {
 
     @Id
-    @Column(name = "team_id")
-    @GeneratedValue
-    private Long id;
-
     @Column(name = "team_name")
     private String name;
 
@@ -39,4 +35,6 @@ public class Team {
     @OneToMany(mappedBy = "team")
     private List<ParticipationMember> participationMembers = new ArrayList<>();
 
+    @OneToMany(mappedBy = "team")
+    private List<ApplicationJoinTeam> applicationJoinTeams = new ArrayList<>();
 }

--- a/football_love/src/main/java/com/deu/football_love/domain/TeamAdmin.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/TeamAdmin.java
@@ -19,6 +19,6 @@ public class TeamAdmin {
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "team_id")
+    @JoinColumn(name = "team_name")
     private Team team;
 }

--- a/football_love/src/main/java/com/deu/football_love/domain/TeamMember.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/TeamMember.java
@@ -1,5 +1,6 @@
 package com.deu.football_love.domain;
 
+import com.deu.football_love.domain.type.AuthorityType;
 import lombok.Data;
 import lombok.Getter;
 
@@ -7,6 +8,9 @@ import javax.persistence.*;
 
 @Entity
 @Data
+@Table(name = "TeamMember", uniqueConstraints = {@UniqueConstraint(
+        name = "TEAM_MEMBER_UNIQUE", columnNames = {"team_name", "member_id"}
+)})
 public class TeamMember {
 
     @Id
@@ -15,10 +19,22 @@ public class TeamMember {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "team_id")
-    Team team;
+    @JoinColumn(name = "team_name")
+    private Team team;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
-    Member member;
+    private Member member;
+
+    private AuthorityType authority;
+
+    public TeamMember(Team team, Member member,AuthorityType authority) {
+        this.team = team;
+        this.member = member;
+        this.authority = authority;
+    }
+
+    protected TeamMember() {
+
+    }
 }

--- a/football_love/src/main/java/com/deu/football_love/domain/type/AuthorityType.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/type/AuthorityType.java
@@ -1,0 +1,5 @@
+package com.deu.football_love.domain.type;
+
+public enum AuthorityType {
+    NONE, MEMBER, ADMIN, LEADER
+}

--- a/football_love/src/main/java/com/deu/football_love/dto/CreateTeamRequest.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/CreateTeamRequest.java
@@ -1,0 +1,8 @@
+package com.deu.football_love.dto;
+
+import lombok.Getter;
+
+@Getter
+public class CreateTeamRequest {
+    private String name;
+}

--- a/football_love/src/main/java/com/deu/football_love/dto/CreateTeamResponse.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/CreateTeamResponse.java
@@ -1,0 +1,4 @@
+package com.deu.football_love.dto;
+
+public class CreateTeamResponse {
+}

--- a/football_love/src/main/java/com/deu/football_love/dto/JoinApplyRequest.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/JoinApplyRequest.java
@@ -1,0 +1,8 @@
+package com.deu.football_love.dto;
+
+import lombok.Getter;
+
+@Getter
+public class JoinApplyRequest {
+    private String Message;
+}

--- a/football_love/src/main/java/com/deu/football_love/dto/TeamDto.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/TeamDto.java
@@ -1,0 +1,28 @@
+package com.deu.football_love.dto;
+
+import com.deu.football_love.domain.*;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TeamDto {
+
+    private String name;
+
+    private LocalDate createDate;
+
+    private List<String> teamMembers = new ArrayList<>();
+
+    public TeamDto(String name, LocalDate createDate, List<TeamMember> teamMembers) {
+        this.name = name;
+        this.createDate = createDate;
+        teamMembers.forEach(teamMember ->{this.teamMembers.add(teamMember.getMember().getId());});
+    }
+
+    public static TeamDto from(Team team)
+    {
+        return new TeamDto(team.getName(),team.getCreateDate(),team.getTeamMembers());
+    }
+
+
+}

--- a/football_love/src/main/java/com/deu/football_love/repository/TeamRepository.java
+++ b/football_love/src/main/java/com/deu/football_love/repository/TeamRepository.java
@@ -1,13 +1,22 @@
 package com.deu.football_love.repository;
 
+import com.deu.football_love.domain.ApplicationJoinTeam;
 import com.deu.football_love.domain.Team;
 import com.deu.football_love.domain.TeamAdmin;
 import com.deu.football_love.domain.TeamMember;
 
+import java.util.List;
+
 public interface TeamRepository {
 
     void insertTeam(TeamAdmin teamAdmin, Team team);
-    Team selectTeam(Long id);
-    Team selectTeamByName(String teamName);
+    Team selectTeam(String teamName);
+    void insertNewApplication(ApplicationJoinTeam application);
     void insertNewTeamMember(TeamMember newTeamMember);
+    ApplicationJoinTeam selectApplication(String teamName, String memberId);
+    void deleteApplication(ApplicationJoinTeam application);
+    void deleteTeamMember(String teamName, String memberId);
+    List<TeamMember> selectTeamMember(String teamName, String memberId);
+    List<TeamAdmin> selectTeamAdmin(String teamName, String memberId);
+    void deleteTeam(Team team);
 }

--- a/football_love/src/main/java/com/deu/football_love/repository/TeamRepositoryImpl.java
+++ b/football_love/src/main/java/com/deu/football_love/repository/TeamRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.deu.football_love.repository;
 
+import com.deu.football_love.domain.ApplicationJoinTeam;
 import com.deu.football_love.domain.Team;
 import com.deu.football_love.domain.TeamAdmin;
 import com.deu.football_love.domain.TeamMember;
@@ -16,27 +17,87 @@ public class TeamRepositoryImpl implements TeamRepository {
 
     private final EntityManager em;
 
+    @Override
     public void insertTeam(TeamAdmin teamAdmin, Team team)
     {
         em.persist(teamAdmin);
         em.persist(team);
     }
-    public Team selectTeam(Long id)
+
+    @Override
+    public Team selectTeam(String teamName)
     {
-        return em.find(Team.class, id);
+        return em.find(Team.class, teamName);
     }
 
-    public Team selectTeamByName(String teamName)
+    @Override
+    public List<TeamMember> selectTeamMember(String teamName, String memberId)
     {
-        List<Team> team = em.createQuery("SELECT t FROM Team t WHERE t.name = :teamName", Team.class).setParameter("teamName", teamName).getResultList();
-        if(team.size() == 1)
-            return team.get(0);
+        if (memberId != null) {
+            return em.createQuery("SELECT tm FROM TeamMember tm WHERE tm.team.name =:teamName AND tm.member.id =:memberId", TeamMember.class)
+                    .setParameter("teamName", teamName)
+                    .setParameter("memberId", memberId)
+                    .getResultList();
+        }
+        else {
+            return em.createQuery("SELECT tm FROM TeamMember tm WHERE tm.team.name =:teamName", TeamMember.class)
+                    .setParameter("teamName", teamName)
+                    .getResultList();
+        }
+
+    }
+
+    @Override
+    public List<TeamAdmin> selectTeamAdmin(String teamName, String memberId)
+    {
+        if(memberId != null) {
+            return em.createQuery("SELECT ta FROM TeamAdmin ta WHERE ta.team.name =:teamName AND ta.member.id =:memberId", TeamAdmin.class)
+                    .setParameter("teamName", teamName)
+                    .setParameter("memberId", memberId)
+                    .getResultList();
+        }
         else
-            return null;
+        {
+            return em.createQuery("SELECT ta FROM TeamAdmin ta WHERE ta.team.name =:teamName", TeamAdmin.class)
+                    .setParameter("teamName", teamName)
+                    .getResultList();
+        }
+
+    }
+
+    @Override
+    public ApplicationJoinTeam selectApplication(String teamName, String memberId) {
+        return em.createQuery("SELECT a FROM ApplicationJoinTeam a WHERE a.team.name =:teamName AND a.member.id=:memberId", ApplicationJoinTeam.class)
+                .setParameter("teamName", teamName)
+                .setParameter("memberId", memberId).getResultList().get(0);
+    }
+    @Override
+    public void insertNewApplication(ApplicationJoinTeam application) {
+        em.persist(application);
     }
 
     @Override
     public void insertNewTeamMember(TeamMember newTeamMember) {
         em.persist(newTeamMember);
+    }
+
+    @Override
+    public void deleteApplication(ApplicationJoinTeam application) {
+        em.remove(application);
+    }
+
+    @Override
+    public void deleteTeamMember(String teamName, String memberId)
+    {
+        em.createQuery("DELETE FROM TeamMember tm WHERE tm.team.name =:teamName AND tm.member.id=:memberId", TeamMember.class)
+                .setParameter("teamName", teamName)
+                .setParameter("memberId", memberId)
+                .getResultList();
+    }
+
+    @Override
+    public void deleteTeam(Team team)
+    {
+        em.remove(team);
     }
 }

--- a/football_love/src/main/java/com/deu/football_love/service/BoardService.java
+++ b/football_love/src/main/java/com/deu/football_love/service/BoardService.java
@@ -3,6 +3,6 @@ package com.deu.football_love.service;
 import com.deu.football_love.domain.Board;
 
 public interface BoardService {
-    Board newBoard(Board board,Long id);
+    Board newBoard(Board board,String teamName);
     boolean deleteBoard(Long id);
 }

--- a/football_love/src/main/java/com/deu/football_love/service/BoardServiceImpl.java
+++ b/football_love/src/main/java/com/deu/football_love/service/BoardServiceImpl.java
@@ -15,8 +15,8 @@ public class BoardServiceImpl implements BoardService {
     private final TeamRepository teamRepository;
 
     @Override
-    public Board newBoard(Board board, Long id) {
-        board.setTeam(teamRepository.selectTeam(id));
+    public Board newBoard(Board board, String teamName) {
+        board.setTeam(teamRepository.selectTeam(teamName));
        return boardRepository.insertNewBoard(board);
     }
 

--- a/football_love/src/main/java/com/deu/football_love/service/TeamService.java
+++ b/football_love/src/main/java/com/deu/football_love/service/TeamService.java
@@ -1,13 +1,21 @@
 package com.deu.football_love.service;
 
-import com.deu.football_love.domain.Member;
-import com.deu.football_love.domain.Team;
-import com.deu.football_love.domain.TeamAdmin;
-import com.deu.football_love.domain.TeamMember;
+import com.deu.football_love.domain.*;
+import com.deu.football_love.domain.type.AuthorityType;
+import com.deu.football_love.dto.TeamDto;
+
+import java.util.List;
 
 public interface TeamService {
 
+    TeamDto getTeamInfo(Team team);
     void createNewTeam(TeamAdmin teamAdmin, Team newTeam);
     Team findTeam(String teamName);
-    void joinTeam(TeamMember newTeamMember);
+    ApplicationJoinTeam findApplication(String teamName, String memberId);
+    void applyToTeam(ApplicationJoinTeam application);
+    void acceptApplication(ApplicationJoinTeam application, TeamMember newTeamMember);
+    AuthorityType authorityCheck(String teamName, String memberId);
+    void withdrawal(String teamName, String memberId);
+    void disbandmentTeam(Team team);
+    List<TeamMember> findTeamMember(String teamName, String memberId);
 }

--- a/football_love/src/main/java/com/deu/football_love/service/TeamServiceImpl.java
+++ b/football_love/src/main/java/com/deu/football_love/service/TeamServiceImpl.java
@@ -1,14 +1,14 @@
 package com.deu.football_love.service;
 
-import com.deu.football_love.domain.Member;
-import com.deu.football_love.domain.Team;
-import com.deu.football_love.domain.TeamAdmin;
-import com.deu.football_love.domain.TeamMember;
-import com.deu.football_love.repository.MemberRepository;
+import com.deu.football_love.domain.*;
+import com.deu.football_love.domain.type.AuthorityType;
+import com.deu.football_love.dto.TeamDto;
 import com.deu.football_love.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Transactional
 @Service
@@ -17,18 +17,73 @@ public class TeamServiceImpl implements TeamService{
 
     private final TeamRepository teamRepository;
 
+    public TeamDto getTeamInfo(Team team)
+    {
+        return TeamDto.from(team);
+    }
+
     @Override
     public void createNewTeam(TeamAdmin admin, Team newTeam) {
         teamRepository.insertTeam(admin,newTeam);
     }
 
+    @Override
     public Team findTeam(String teamName)
     {
-        return teamRepository.selectTeamByName(teamName);
+        return teamRepository.selectTeam(teamName);
     }
 
-    public void joinTeam(TeamMember newTeamMember)
-    {
+    @Override
+    public ApplicationJoinTeam findApplication(String teamName, String memberId) {
+        return teamRepository.selectApplication(teamName, memberId);
+    }
+    @Override
+    public void applyToTeam(ApplicationJoinTeam application) {
+        teamRepository.insertNewApplication(application);
+    }
+
+    @Override
+    public void acceptApplication(ApplicationJoinTeam application, TeamMember newTeamMember) {
+        teamRepository.deleteApplication(application);
         teamRepository.insertNewTeamMember(newTeamMember);
     }
+
+    /**
+     *  팀에 속해 있는지, 속해 있다면 일반 회원인지 관리자인지 파악
+     * 
+     */
+    @Override
+    public AuthorityType authorityCheck(String teamName, String memberId)
+    {
+        List<TeamMember> teamMembers = teamRepository.selectTeamMember(teamName, memberId);
+
+        if(teamMembers.size() == 0)
+            return AuthorityType.NONE;
+        else
+        {
+            List<TeamAdmin> teamAdmins = teamRepository.selectTeamAdmin(teamName, memberId);
+            if (teamAdmins.size() == 0)
+                return AuthorityType.MEMBER;
+            else
+                return AuthorityType.ADMIN;
+        }
+    }
+
+    @Override
+    public List<TeamMember> findTeamMember(String teamName, String memberId)
+    {
+        return teamRepository.selectTeamMember(teamName, memberId);
+    }
+    @Override
+    public void withdrawal(String teamName, String memberId)
+    {
+        teamRepository.deleteTeamMember(teamName, memberId);
+    }
+
+    @Override
+    public void disbandmentTeam(Team team)
+    {
+        teamRepository.deleteTeam(team);
+    }
+
 }


### PR DESCRIPTION
# 📙 작업 내역

구현 내용 및 작업 했던 내역

- 가입신청 Entity추가
- 회원 등급 Enum 추가
- Team 관련 DTO 추가
- 팀 회원 권한 조회, 팀 멤버 조회, 팀 해체 Service 추가
- 팀 조회, 팀 멤버조회, 팀 어드민 조회, 팀 가입신청 조회, 팀 가입 신청, 팀 가입, 팀 멤버 삭제, 팀 삭제
- 팀 이름, 멤버 Id를 유니크 키로 지정, 회원 등급 필드 추가
- 팀 id 필드 삭제
- 팀 id 필드 삭제로인해 Team과의 매핑은 team_name으로 변경
- 팀조회, 팀 이름 중복 체크,팀 가입 신청, 팀 가입 수락, 팀 멤버 탈퇴, 팀 해체 API 작성
- 회원정보 수정요청과 uri 중복으로인해 임시 변경
- 팀 가입 신청 Entity 추가로인한 매핑
- team Id필드 삭제로인해 Team과의 매핑은 teamName으로 변경

# 작업 유형

- [x] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

# 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

# 📝 PR 특이 사항
-
