### PR TITLE
Backend - 2021-11-15, 2021-11-16 작업 내용

### DIFF
--- a/football_love/src/main/java/com/deu/football_love/controller/CompanyController.java
+++ b/football_love/src/main/java/com/deu/football_love/controller/CompanyController.java
@@ -1,0 +1,14 @@
+package com.deu.football_love.controller;
+
+
+import com.deu.football_love.service.CompanyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController("/company")
+@RequiredArgsConstructor
+public class CompanyController {
+    private final CompanyService companyService;
+
+
+}

--- a/football_love/src/main/java/com/deu/football_love/controller/MatchController.java
+++ b/football_love/src/main/java/com/deu/football_love/controller/MatchController.java
@@ -1,0 +1,38 @@
+package com.deu.football_love.controller;
+
+import com.deu.football_love.domain.type.AuthorityType;
+import com.deu.football_love.dto.CreateMatchRequest;
+import com.deu.football_love.dto.MemberDto;
+import com.deu.football_love.service.MatchService;
+import com.deu.football_love.service.MemberService;
+import com.deu.football_love.service.TeamService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpSession;
+
+@RestController("/match")
+@RequiredArgsConstructor
+public class MatchController {
+
+    private final MatchService matchService;
+    private final MemberService memberService;
+    private final TeamService teamService;
+
+    @PostMapping
+    public ResponseEntity add(HttpSession session, CreateMatchRequest request)
+    {
+        MemberDto sessionMember = memberService.findMember(((MemberDto) session.getAttribute("memberInfo")).getId());
+        AuthorityType authorityType = teamService.authorityCheck(request.getTeamName(), sessionMember.getId());
+        if (sessionMember == null || (authorityType != AuthorityType.ADMIN && authorityType != AuthorityType.LEADER))
+        {
+            return new ResponseEntity(HttpStatus.UNAUTHORIZED);
+        }
+
+    }
+
+}

--- a/football_love/src/main/java/com/deu/football_love/controller/PostController.java
+++ b/football_love/src/main/java/com/deu/football_love/controller/PostController.java
@@ -1,16 +1,11 @@
 package com.deu.football_love.controller;
 
 import com.deu.football_love.domain.Board;
-import com.deu.football_love.domain.Member;
-import com.deu.football_love.domain.Post;
-import com.deu.football_love.dto.UpdatePostRequest;
-import com.deu.football_love.dto.WritePostRequest;
-import com.deu.football_love.dto.WritePostResponse;
+import com.deu.football_love.dto.*;
 import com.deu.football_love.service.BoardService;
 import com.deu.football_love.service.MemberService;
 import com.deu.football_love.service.PostService;
 import com.deu.football_love.service.TeamService;
-import io.swagger.models.Response;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -35,12 +30,10 @@ public class PostController {
                                     , WritePostRequest writePostRequest, HttpSession session)
     {
         Board board = new Board();// board 조회
-        Member sessionMember = memberService.findMember(((Member) session.getAttribute("memberInfo")).getId());
+        MemberDto sessionMember = memberService.findMember(((MemberDto) session.getAttribute("memberInfo")).getId());
         if (sessionMember == null || board == null || teamService.findTeamMember(teamName, sessionMember.getId()).size() == 0)
             return new ResponseEntity(HttpStatus.UNAUTHORIZED);
-        Post newPost = new Post(sessionMember, board, writePostRequest.getCreateDate()
-                , writePostRequest.getModifyDate(), writePostRequest.getTitle(), writePostRequest.getContent());
-        WritePostResponse writePostResponse = postService.writePost(newPost);
+        WritePostResponse writePostResponse = postService.writePost(writePostRequest);
         return new ResponseEntity(writePostResponse, HttpStatus.OK);
     }
 
@@ -48,17 +41,17 @@ public class PostController {
      * 게시글 삭제
      */
     @DeleteMapping("/post/{postId}")
-    public ResponseEntity deletePost(@PathVariable Long postId, WritePostRequest writePostRequest, HttpSession session)
+    public ResponseEntity deletePost(@PathVariable Long postId, DeletePostRequest request, HttpSession session)
     {
-        Member sessionMember = memberService.findMember(((Member) session.getAttribute("memberInfo")).getId());
-        Post findPost = postService.findPost(postId);
+        MemberDto sessionMember = memberService.findMember(((MemberDto) session.getAttribute("memberInfo")).getId());
+        PostDto findPost = postService.findPost(postId);
 
         if (findPost == null)
             return new ResponseEntity(HttpStatus.BAD_REQUEST);
-        if (sessionMember == null || sessionMember.getId() != findPost.getAuthor().getId())
+        if (sessionMember == null || sessionMember.getId() != findPost.getAuthorId())
             return new ResponseEntity(HttpStatus.UNAUTHORIZED);
-        postService.deletePost(findPost);
-        return new ResponseEntity(HttpStatus.OK);
+        DeletePostResponse response = postService.deletePost(findPost.getId());
+        return new ResponseEntity(response, HttpStatus.OK);
     }
 
     /**
@@ -67,14 +60,14 @@ public class PostController {
     @PutMapping("/post/{postId}")
     public ResponseEntity modifyPost(@PathVariable Long postId, UpdatePostRequest request, HttpSession session)
     {
-        Member sessionMember = memberService.findMember(((Member) session.getAttribute("memberInfo")).getId());
-        Post findPost = postService.findPost(postId);
+        MemberDto sessionMember = memberService.findMember(((MemberDto) session.getAttribute("memberInfo")).getId());
+        PostDto findPost = postService.findPost(postId);
 
         if (findPost == null)
             return new ResponseEntity(HttpStatus.BAD_REQUEST);
-        if (sessionMember == null || sessionMember.getId() != findPost.getAuthor().getId())
+        if (sessionMember == null || sessionMember.getId() != findPost.getAuthorId())
             return new ResponseEntity(HttpStatus.UNAUTHORIZED);
-        postService.modifyPost(findPost, request);
+        postService.modifyPost(postId, request);
         return new ResponseEntity(HttpStatus.OK);
     }
 

--- a/football_love/src/main/java/com/deu/football_love/controller/StadiumController.java
+++ b/football_love/src/main/java/com/deu/football_love/controller/StadiumController.java
@@ -1,0 +1,11 @@
+package com.deu.football_love.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController("/stadium")
+@RequiredArgsConstructor
+public class StadiumController
+{
+
+}

--- a/football_love/src/main/java/com/deu/football_love/domain/ApplicationJoinTeam.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/ApplicationJoinTeam.java
@@ -1,10 +1,12 @@
 package com.deu.football_love.domain;
 
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
+@Getter
 public class ApplicationJoinTeam {
 
     @Id

--- a/football_love/src/main/java/com/deu/football_love/domain/Company.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/Company.java
@@ -1,10 +1,15 @@
 package com.deu.football_love.domain;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Getter
+@NoArgsConstructor
 public class Company {
 
     @Id
@@ -27,4 +32,11 @@ public class Company {
 
     @OneToMany(mappedBy = "id")
     private List<Stadium> stadiums = new ArrayList<>();
+
+    public Company(String name, Address location, String tel, String description) {
+        this.name = name;
+        this.location = location;
+        this.tel = tel;
+        this.description = description;
+    }
 }

--- a/football_love/src/main/java/com/deu/football_love/domain/Matches.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/Matches.java
@@ -1,9 +1,13 @@
 package com.deu.football_love.domain;
 
+import lombok.Data;
+import lombok.Setter;
+
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
+@Data
 public class Matches {
     @Id
     @GeneratedValue
@@ -19,7 +23,7 @@ public class Matches {
     private Stadium stadium;
 
     @Column(name = "matches_reservation_time")
-    private LocalDateTime reservation_time;
+    private LocalDateTime reservationTime;
 
     @Column(name="matches_approval")
     private Boolean approval;

--- a/football_love/src/main/java/com/deu/football_love/domain/Member.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/Member.java
@@ -46,7 +46,7 @@ public class Member {
 	@OneToMany(mappedBy = "author")
 	private List<Post> posts = new ArrayList<>();
 
-	@OneToMany(mappedBy = "member" , cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+	@OneToMany(mappedBy = "member" )
 	private List<TeamMember> teamMembers = new ArrayList<>();
 
 	@OneToMany(mappedBy = "member")

--- a/football_love/src/main/java/com/deu/football_love/domain/Post.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/Post.java
@@ -6,8 +6,6 @@ import lombok.Setter;
 
 import javax.persistence.*;
 
-import lombok.Getter;
-
 import java.time.LocalDateTime;
 
 @Entity
@@ -40,7 +38,7 @@ public class Post {
     @Column(name= "post_content")
     private String content;
 
-    protected Post() {
+    public Post() {
     }
 
     public Post(Member author, Board board, LocalDateTime createDate, LocalDateTime modifyDate, String title, String content) {
@@ -51,6 +49,7 @@ public class Post {
         this.title = title;
         this.content = content;
     }
+
 
     public void update(UpdatePostRequest request)
     {

--- a/football_love/src/main/java/com/deu/football_love/domain/Stadium.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/Stadium.java
@@ -1,10 +1,13 @@
 package com.deu.football_love.domain;
 
+import lombok.Getter;
+
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Getter
 public class Stadium {
 
     @Id

--- a/football_love/src/main/java/com/deu/football_love/domain/Team.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/Team.java
@@ -20,7 +20,7 @@ public class Team {
     @Column(name="team_createdate")
     private LocalDate createDate;
 
-    @OneToMany(mappedBy = "team", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    @OneToMany(mappedBy = "team" ,cascade = CascadeType.ALL)
     private List<TeamMember> teamMembers = new ArrayList<>();
 
     @OneToMany(mappedBy = "team")

--- a/football_love/src/main/java/com/deu/football_love/domain/TeamMember.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/TeamMember.java
@@ -2,7 +2,6 @@ package com.deu.football_love.domain;
 
 import com.deu.football_love.domain.type.AuthorityType;
 import lombok.Data;
-import lombok.Getter;
 
 import javax.persistence.*;
 
@@ -28,7 +27,7 @@ public class TeamMember {
 
     private AuthorityType authority;
 
-    public TeamMember(Team team, Member member,AuthorityType authority) {
+    public TeamMember(Team team, Member member, AuthorityType authority) {
         this.team = team;
         this.member = member;
         this.authority = authority;

--- a/football_love/src/main/java/com/deu/football_love/dto/AcceptApplicationResponse.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/AcceptApplicationResponse.java
@@ -1,0 +1,12 @@
+package com.deu.football_love.dto;
+
+
+public class AcceptApplicationResponse {
+    private String teamName;
+    private String memberId;
+
+    public AcceptApplicationResponse(String teamName, String memberId) {
+        this.teamName = teamName;
+        this.memberId = memberId;
+    }
+}

--- a/football_love/src/main/java/com/deu/football_love/dto/AddCompanyResponse.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/AddCompanyResponse.java
@@ -1,0 +1,27 @@
+package com.deu.football_love.dto;
+
+import com.deu.football_love.domain.Address;
+import com.deu.football_love.domain.Company;
+import lombok.Getter;
+
+@Getter
+public class AddCompanyResponse {
+    private Long companyId;
+    private String companyName;
+    private Address location;
+    private String tel;
+    private String description;
+
+    public AddCompanyResponse(Long id, String name, Address location, String tel, String description) {
+        this.companyId = id;
+        this.companyName =name;
+        this.location = location;
+        this.tel = tel;
+        this.description = description;
+    }
+
+    public static AddCompanyResponse from(Company company)
+    {
+        return new AddCompanyResponse(company.getId(), company.getName(), company.getLocation(),company.getTel(), company.getDescription());
+    }
+}

--- a/football_love/src/main/java/com/deu/football_love/dto/AddStadiumResponse.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/AddStadiumResponse.java
@@ -1,0 +1,24 @@
+package com.deu.football_love.dto;
+
+import com.deu.football_love.domain.Stadium;
+import lombok.Getter;
+
+@Getter
+public class AddStadiumResponse {
+    private Long id;
+    private String type;
+    private String size;
+    private Long cost;
+
+    public AddStadiumResponse(Long id, String type, String size, Long cost) {
+        this.id = id;
+        this.type = type;
+        this.size = size;
+        this.cost = cost;
+    }
+
+    public static AddStadiumResponse from(Stadium stadium)
+    {
+        return new AddStadiumResponse(stadium.getId(), stadium.getType(), stadium.getSize(), stadium.getCost());
+    }
+}

--- a/football_love/src/main/java/com/deu/football_love/dto/ApplicationJoinTeamDto.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/ApplicationJoinTeamDto.java
@@ -1,0 +1,22 @@
+package com.deu.football_love.dto;
+
+import com.deu.football_love.domain.ApplicationJoinTeam;
+import lombok.Getter;
+
+@Getter
+public class ApplicationJoinTeamDto {
+    private Long id;
+
+    private String teamName;
+
+    private String memberId;
+
+    private String message;
+
+    public ApplicationJoinTeamDto(ApplicationJoinTeam applicationJoinTeam) {
+        this.id = applicationJoinTeam.getId();
+        this.teamName = applicationJoinTeam.getTeam().getName();
+        this.memberId = applicationJoinTeam.getMember().getId();
+        this.message = applicationJoinTeam.getMessage();
+    }
+}

--- a/football_love/src/main/java/com/deu/football_love/dto/CompanyDto.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/CompanyDto.java
@@ -1,0 +1,25 @@
+package com.deu.football_love.dto;
+
+import com.deu.football_love.domain.Address;
+import com.deu.football_love.domain.Company;
+
+public class CompanyDto {
+    private Long companyId;
+    private String companyName;
+    private Address location;
+    private String tel;
+    private String description;
+
+    public CompanyDto(Long id, String name, Address location, String tel, String description) {
+        this.companyId = id;
+        this.companyName =name;
+        this.location = location;
+        this.tel = tel;
+        this.description = description;
+    }
+
+    public static CompanyDto from(Company company)
+    {
+        return new CompanyDto(company.getId(), company.getName(), company.getLocation(),company.getTel(), company.getDescription());
+    }
+}

--- a/football_love/src/main/java/com/deu/football_love/dto/CreateMatchRequest.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/CreateMatchRequest.java
@@ -1,0 +1,12 @@
+package com.deu.football_love.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CreateMatchRequest {
+    private String teamName;
+    private Long stadiumId;
+    private LocalDateTime reservation_time;
+}

--- a/football_love/src/main/java/com/deu/football_love/dto/CreateMatchResponse.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/CreateMatchResponse.java
@@ -1,0 +1,25 @@
+package com.deu.football_love.dto;
+
+import com.deu.football_love.domain.Matches;
+
+import java.time.LocalDateTime;
+
+public class CreateMatchResponse {
+    private Long matchId;
+    private String teamName;
+    private Long stadiumId;
+    private LocalDateTime reservation_time;
+
+
+    public CreateMatchResponse(Long matchId, String teamName, Long stadiumId, LocalDateTime reservation_time) {
+        this.matchId = matchId;
+        this.teamName = teamName;
+        this.stadiumId = stadiumId;
+        this.reservation_time = reservation_time;
+    }
+
+    public static CreateMatchResponse from(Matches match)
+    {
+        return new CreateMatchResponse(match.getId(), match.getTeam().getName(), match.getStadium().getId(), match.getReservationTime());
+    }
+}

--- a/football_love/src/main/java/com/deu/football_love/dto/CreateTeamResponse.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/CreateTeamResponse.java
@@ -1,4 +1,9 @@
 package com.deu.football_love.dto;
 
 public class CreateTeamResponse {
+    private String teamName;
+
+    public CreateTeamResponse(String teamName) {
+        this.teamName = teamName;
+    }
 }

--- a/football_love/src/main/java/com/deu/football_love/dto/DeletePostResponse.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/DeletePostResponse.java
@@ -1,0 +1,12 @@
+package com.deu.football_love.dto;
+
+import lombok.Getter;
+
+@Getter
+public class DeletePostResponse {
+    private Long postId;
+
+    public DeletePostResponse(Long postId) {
+        this.postId = postId;
+    }
+}

--- a/football_love/src/main/java/com/deu/football_love/dto/DisbandmentTeamResponse.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/DisbandmentTeamResponse.java
@@ -1,0 +1,12 @@
+package com.deu.football_love.dto;
+
+import lombok.Getter;
+
+@Getter
+public class DisbandmentTeamResponse {
+    private String teamName;
+
+    public DisbandmentTeamResponse(String teamName) {
+        this.teamName = teamName;
+    }
+}

--- a/football_love/src/main/java/com/deu/football_love/dto/MatchDto.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/MatchDto.java
@@ -1,0 +1,24 @@
+package com.deu.football_love.dto;
+
+import com.deu.football_love.domain.Matches;
+
+import java.time.LocalDateTime;
+
+public class MatchDto {
+    private Long matchId;
+    private String teamName;
+    private Long stadiumId;
+    private LocalDateTime reservation_time;
+
+    public MatchDto(Long matchId, String teamName, Long stadiumId, LocalDateTime reservation_time) {
+        this.matchId = matchId;
+        this.teamName = teamName;
+        this.stadiumId = stadiumId;
+        this.reservation_time = reservation_time;
+    }
+
+    public static MatchDto from(Matches match)
+    {
+        return new MatchDto(match.getId(), match.getTeam().getName(), match.getStadium().getId(), match.getReservationTime());
+    }
+}

--- a/football_love/src/main/java/com/deu/football_love/dto/MemberDto.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/MemberDto.java
@@ -32,8 +32,6 @@ public class MemberDto {
 	
 	private List<Long> postId;
 	
-	private List<Long> adminsId;
-	
 	private List<Long> teamMembersId;
 	
 	private List<Long> participationMembersId;
@@ -49,9 +47,9 @@ public class MemberDto {
 		this.address = member.getAddress();
 		this.email = member.getEmail();
 		this.phone = member.getPhone();
+		if(member.getWithdrawalMember() != null)
 		this.withdrawalMemberId = member.getWithdrawalMember().getId();
 		member.getPosts().forEach(post -> postId.add(post.getId()));
-		member.getAdmins().forEach(admin -> adminsId.add(admin.getId()));
 		member.getTeamMembers().forEach(teamMember -> postId.add(teamMember.getId()));
 		member.getParticipationMembers().forEach(participation -> postId.add(participation.getId()));
 	}

--- a/football_love/src/main/java/com/deu/football_love/dto/ModifyPostResponse.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/ModifyPostResponse.java
@@ -1,0 +1,9 @@
+package com.deu.football_love.dto;
+
+public class ModifyPostResponse {
+    Long postId;
+
+    public ModifyPostResponse(Long postId) {
+        this.postId = postId;
+    }
+}

--- a/football_love/src/main/java/com/deu/football_love/dto/PostDto.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/PostDto.java
@@ -1,0 +1,45 @@
+package com.deu.football_love.dto;
+
+import com.deu.football_love.domain.Board;
+import com.deu.football_love.domain.Member;
+import com.deu.football_love.domain.Post;
+import lombok.Getter;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+public class PostDto {
+
+
+    private Long id;
+
+    private String authorId;
+
+    private Long boardId;
+
+    private LocalDateTime createDate;
+
+    private LocalDateTime modifyDate;
+
+    private String title;
+
+    private String content;
+
+    public PostDto(Long id, String authorId, Long boardId, LocalDateTime createDate, LocalDateTime modifyDate, String title, String content) {
+        this.id = id;
+        this.authorId = authorId;
+        this.boardId = boardId;
+        this.createDate = createDate;
+        this.modifyDate = modifyDate;
+        this.title = title;
+        this.content = content;
+    }
+
+    public static PostDto from(Post post)
+    {
+       return new PostDto(post.getId(), post.getAuthor().getId(),post.getBoard().getId(), post.getCreateDate(), post.getModifyDate(), post.getTitle(), post.getContent());
+    }
+
+
+}

--- a/football_love/src/main/java/com/deu/football_love/dto/RemoveStadiumResponse.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/RemoveStadiumResponse.java
@@ -1,0 +1,11 @@
+package com.deu.football_love.dto;
+
+import lombok.Getter;
+
+public class RemoveStadiumResponse {
+    private Long stadiumId;
+
+    public RemoveStadiumResponse(Long stadiumId) {
+        this.stadiumId = stadiumId;
+    }
+}

--- a/football_love/src/main/java/com/deu/football_love/dto/StadiumDto.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/StadiumDto.java
@@ -1,0 +1,22 @@
+package com.deu.football_love.dto;
+
+import com.deu.football_love.domain.Stadium;
+
+public class StadiumDto {
+    private Long id;
+    private String type;
+    private String size;
+    private Long cost;
+
+    public StadiumDto(Long id, String type, String size, Long cost) {
+        this.id = id;
+        this.type = type;
+        this.size = size;
+        this.cost = cost;
+    }
+
+    public static StadiumDto from(Stadium stadium)
+    {
+        return new StadiumDto(stadium.getId(), stadium.getType(), stadium.getSize(), stadium.getCost());
+    }
+}

--- a/football_love/src/main/java/com/deu/football_love/dto/TeamDto.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/TeamDto.java
@@ -1,10 +1,13 @@
 package com.deu.football_love.dto;
 
 import com.deu.football_love.domain.*;
+import lombok.Getter;
+
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
+@Getter
 public class TeamDto {
 
     private String name;

--- a/football_love/src/main/java/com/deu/football_love/dto/TeamMemberDto.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/TeamMemberDto.java
@@ -1,0 +1,24 @@
+package com.deu.football_love.dto;
+
+import com.deu.football_love.domain.TeamMember;
+import com.deu.football_love.domain.type.AuthorityType;
+import lombok.Getter;
+
+@Getter
+public class TeamMemberDto {
+
+    private Long id;
+
+    private String teamName;
+
+    private String memberId;
+
+    private AuthorityType authority;
+
+    public TeamMemberDto(TeamMember teamMember) {
+        this.id = teamMember.getId();
+        this.teamName = teamMember.getTeam().getName();
+        this.memberId = teamMember.getMember().getId();
+        this.authority = teamMember.getAuthority();
+    }
+}

--- a/football_love/src/main/java/com/deu/football_love/dto/UpdateAuthorityResponse.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/UpdateAuthorityResponse.java
@@ -1,0 +1,15 @@
+package com.deu.football_love.dto;
+
+import com.deu.football_love.domain.type.AuthorityType;
+
+public class UpdateAuthorityResponse {
+    private String teamName;
+    private String memberId;
+    private AuthorityType authorityType;
+
+    public UpdateAuthorityResponse(String teamName, String memberId, AuthorityType authorityType) {
+        this.teamName = teamName;
+        this.memberId = memberId;
+        this.authorityType = authorityType;
+    }
+}

--- a/football_love/src/main/java/com/deu/football_love/dto/WithdrawalCompanyResponse.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/WithdrawalCompanyResponse.java
@@ -1,0 +1,12 @@
+package com.deu.football_love.dto;
+
+public class WithdrawalCompanyResponse {
+    private Long companyId;
+    private String companyName;
+
+    public WithdrawalCompanyResponse(Long companyId, String companyName) {
+        this.companyId = companyId;
+        this.companyName = companyName;
+    }
+}
++1

--- a/football_love/src/main/java/com/deu/football_love/dto/WritePostRequest.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/WritePostRequest.java
@@ -6,8 +6,6 @@ import java.time.LocalDateTime;
 
 @Data
 public class WritePostRequest {
-
-
     private String Author;
     private Long boardId;
     private LocalDateTime createDate;

--- a/football_love/src/main/java/com/deu/football_love/repository/CompanyRepository.java
+++ b/football_love/src/main/java/com/deu/football_love/repository/CompanyRepository.java
@@ -1,0 +1,29 @@
+package com.deu.football_love.repository;
+
+import com.deu.football_love.domain.Company;
+import com.deu.football_love.domain.Team;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+
+@Repository
+@RequiredArgsConstructor
+public class CompanyRepository {
+    private final EntityManager em;
+
+    public Company selectCompany(Long companyId)
+    {
+        return em.find(Company.class, companyId);
+    }
+
+    public void insertCompany(Company company)
+    {
+        em.persist(company);
+    }
+
+    public void deleteCompany(Company company)
+    {
+        em.remove(company);
+    }
+}

--- a/football_love/src/main/java/com/deu/football_love/repository/MatchRepository.java
+++ b/football_love/src/main/java/com/deu/football_love/repository/MatchRepository.java
@@ -1,0 +1,25 @@
+package com.deu.football_love.repository;
+
+import com.deu.football_love.domain.Matches;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+
+@Repository
+@RequiredArgsConstructor
+public class MatchRepository {
+
+    private final EntityManager em;
+
+    public Matches selectMatch(Long id)
+    {
+        return em.find(Matches.class, id);
+    }
+
+    public void insertMatch(Matches match)
+    {
+        em.persist(match);
+    }
+
+}

--- a/football_love/src/main/java/com/deu/football_love/repository/StadiumRepository.java
+++ b/football_love/src/main/java/com/deu/football_love/repository/StadiumRepository.java
@@ -1,0 +1,29 @@
+package com.deu.football_love.repository;
+
+import com.deu.football_love.domain.Stadium;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+
+@Repository
+@RequiredArgsConstructor
+public class StadiumRepository {
+
+    private final EntityManager em;
+
+    public Stadium selectStadium(Long stadiumId)
+    {
+        return em.find(Stadium.class, stadiumId);
+    }
+
+    public void insertStadium(Stadium stadium)
+    {
+        em.persist(stadium);
+    }
+
+    public void deleteStadium(Stadium stadium)
+    {
+        em.remove(stadium);
+    }
+}

--- a/football_love/src/main/java/com/deu/football_love/service/CompanyService.java
+++ b/football_love/src/main/java/com/deu/football_love/service/CompanyService.java
@@ -1,0 +1,45 @@
+package com.deu.football_love.service;
+
+import com.deu.football_love.domain.Address;
+import com.deu.football_love.domain.Company;
+import com.deu.football_love.dto.AddCompanyResponse;
+import com.deu.football_love.dto.CompanyDto;
+import com.deu.football_love.dto.WithdrawalCompanyResponse;
+import com.deu.football_love.repository.CompanyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CompanyService {
+
+    private final CompanyRepository companyRepository;
+
+    @Transactional(readOnly = true)
+    public CompanyDto findCompany(Long companyId)
+    {
+        Company findCompany = companyRepository.selectCompany(companyId);
+        if (findCompany == null)
+            return null;
+        return CompanyDto.from(findCompany);
+    }
+
+    @Transactional
+    public AddCompanyResponse addCompany(String name, Address location, String tel, String description)
+    {
+        Company newCompany = new Company(name, location, tel, description);
+        companyRepository.insertCompany(newCompany);
+        return AddCompanyResponse.from(newCompany);
+    }
+
+    @Transactional
+    public WithdrawalCompanyResponse withdrawalCompany(Long companyId)
+    {
+        Company findCompany = companyRepository.selectCompany(companyId);
+        if(findCompany == null)
+            return null;
+        companyRepository.deleteCompany(findCompany);
+        return new WithdrawalCompanyResponse(companyId, findCompany.getName());
+    }
+}

--- a/football_love/src/main/java/com/deu/football_love/service/MatchService.java
+++ b/football_love/src/main/java/com/deu/football_love/service/MatchService.java
@@ -1,0 +1,52 @@
+package com.deu.football_love.service;
+
+import com.deu.football_love.domain.Matches;
+import com.deu.football_love.domain.Stadium;
+import com.deu.football_love.domain.Team;
+import com.deu.football_love.dto.CreateMatchResponse;
+import com.deu.football_love.dto.MatchDto;
+import com.deu.football_love.repository.MatchRepository;
+import com.deu.football_love.repository.StadiumRepository;
+import com.deu.football_love.repository.TeamRepository;
+import com.fasterxml.jackson.databind.deser.DataFormatReaders;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class MatchService {
+
+    private final MatchRepository matchRepository;
+    private final TeamRepository teamRepository;
+    private final StadiumRepository stadiumRepository;
+
+    @Transactional(readOnly = true)
+    public MatchDto findMatch(Long matchId)
+    {
+        Matches findMatch = matchRepository.selectMatch(matchId);
+        if (findMatch == null)
+            return null;
+        return MatchDto.from(findMatch);
+    }
+
+    @Transactional
+    public CreateMatchResponse addMatch(String teamName, Long stadiumId, LocalDateTime reservationTime)
+    {
+        Team findTeam = teamRepository.selectTeam(teamName);
+        Stadium findStadium = stadiumRepository.selectStadium(stadiumId);
+
+        Matches newMatch = new Matches();
+        newMatch.setTeam(findTeam);
+        newMatch.setStadium(findStadium);
+        newMatch.setReservationTime(reservationTime);
+        newMatch.setApproval(false);
+        matchRepository.insertMatch(newMatch);
+        return CreateMatchResponse.from(newMatch);
+    }
+
+
+
+}

--- a/football_love/src/main/java/com/deu/football_love/service/PostService.java
+++ b/football_love/src/main/java/com/deu/football_love/service/PostService.java
@@ -1,17 +1,10 @@
 package com.deu.football_love.service;
 
-import com.deu.football_love.domain.Post;
-import com.deu.football_love.dto.UpdatePostRequest;
-import com.deu.football_love.dto.WritePostResponse;
-import org.springframework.transaction.annotation.Transactional;
+import com.deu.football_love.dto.*;
 
 public interface PostService {
-    WritePostResponse writePost(Post post);
-    void deletePost(Post post);
-
-    @Transactional
-    void modifyPost(Post post, UpdatePostRequest request);
-
-    @Transactional
-    Post findPost(Long postId);
+    WritePostResponse writePost(WritePostRequest request);
+    DeletePostResponse deletePost(Long postId);
+    ModifyPostResponse modifyPost(Long postId, UpdatePostRequest request);
+    PostDto findPost(Long postId);
 }

--- a/football_love/src/main/java/com/deu/football_love/service/PostServiceImpl.java
+++ b/football_love/src/main/java/com/deu/football_love/service/PostServiceImpl.java
@@ -1,9 +1,10 @@
 package com.deu.football_love.service;
 
+import com.deu.football_love.domain.Member;
 import com.deu.football_love.domain.Post;
-import com.deu.football_love.dto.DeletePostRequest;
-import com.deu.football_love.dto.UpdatePostRequest;
-import com.deu.football_love.dto.WritePostResponse;
+import com.deu.football_love.dto.*;
+import com.deu.football_love.repository.BoardRepository;
+import com.deu.football_love.repository.MemberRepository;
 import com.deu.football_love.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,30 +15,51 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostServiceImpl implements PostService{
 
     private final PostRepository postRepository;
-
+    private final BoardRepository boardRepository;
+    private final MemberRepository memberRepository;
     @Override
-    @Transactional
-    public WritePostResponse writePost(Post post) {
-        postRepository.insertPost(post);
-        return WritePostResponse.from(post);
+
+    @Transactional(readOnly = false)
+    public WritePostResponse writePost(WritePostRequest request) {
+        Post newPost = new Post();
+        Member findMember = memberRepository.selectMember(request.getAuthor());
+        newPost.setContent(request.getContent());
+        newPost.setTitle(request.getTitle());
+        newPost.setAuthor(findMember);
+        newPost.setCreateDate(request.getCreateDate());
+        newPost.setModifyDate(request.getModifyDate());
+        /*newPost.setBoard(findBoard);*/
+        postRepository.insertPost(newPost);
+        return WritePostResponse.from(newPost);
     }
 
     @Override
-    @Transactional
-    public void deletePost(Post post) {
-        postRepository.insertPost(post);
+    @Transactional(readOnly = false)
+    public DeletePostResponse deletePost(Long postId) {
+        Post post = postRepository.selectPost(postId);
+        if (post == null)
+            return null;
+        postRepository.deletePost(post);
+        return new DeletePostResponse(postId);
     }
 
     @Override
-    @Transactional
-    public void modifyPost(Post post, UpdatePostRequest request)
+    @Transactional(readOnly = false)
+    public ModifyPostResponse modifyPost(Long postId, UpdatePostRequest request)
     {
+        Post post = postRepository.selectPost(postId);
+        if (post == null)
+            return null;
         post.update(request);
+        return new ModifyPostResponse(postId);
     }
 
     @Override
-    @Transactional
-    public Post findPost(Long postId) {
-        return postRepository.selectPost(postId);
+    @Transactional(readOnly = true)
+    public PostDto findPost(Long postId) {
+        Post post = postRepository.selectPost(postId);
+        if (post == null)
+            return null;
+        return PostDto.from(post);
     }
 }

--- a/football_love/src/main/java/com/deu/football_love/service/StadiumService.java
+++ b/football_love/src/main/java/com/deu/football_love/service/StadiumService.java
@@ -1,0 +1,44 @@
+package com.deu.football_love.service;
+
+import com.deu.football_love.domain.Stadium;
+import com.deu.football_love.dto.AddStadiumResponse;
+import com.deu.football_love.dto.RemoveStadiumResponse;
+import com.deu.football_love.dto.StadiumDto;
+import com.deu.football_love.repository.StadiumRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StadiumService {
+
+    private final StadiumRepository stadiumRepository;
+
+    @Transactional(readOnly = true)
+    public StadiumDto findStadium(Long stadiumId)
+    {
+        Stadium findStadium = stadiumRepository.selectStadium(stadiumId);
+        if (findStadium == null)
+            return null;
+        return StadiumDto.from(findStadium);
+    }
+
+    @Transactional
+    public AddStadiumResponse addStadium()
+    {
+        Stadium newStadium = new Stadium();
+        stadiumRepository.insertStadium(newStadium);
+        return AddStadiumResponse.from(newStadium);
+    }
+
+    @Transactional
+    public RemoveStadiumResponse removeStadium(Long stadiumId)
+    {
+        Stadium findStadium = stadiumRepository.selectStadium(stadiumId);
+        if(findStadium == null)
+            return null;
+        stadiumRepository.deleteStadium(findStadium);
+        return new RemoveStadiumResponse(stadiumId);
+    }
+}

--- a/football_love/src/main/java/com/deu/football_love/service/TeamService.java
+++ b/football_love/src/main/java/com/deu/football_love/service/TeamService.java
@@ -2,21 +2,21 @@ package com.deu.football_love.service;
 
 import com.deu.football_love.domain.*;
 import com.deu.football_love.domain.type.AuthorityType;
-import com.deu.football_love.dto.TeamDto;
+import com.deu.football_love.dto.*;
 
 import java.util.List;
 
 public interface TeamService {
 
-    TeamDto getTeamInfo(Team team);
-    void createNewTeam(Team team);
-    Team findTeam(String teamName);
-    ApplicationJoinTeam findApplication(String teamName, String memberId);
-    void applyToTeam(ApplicationJoinTeam application);
-    void acceptApplication(ApplicationJoinTeam application, TeamMember newTeamMember);
+    TeamDto getTeamInfo(String teamName);
+    CreateTeamResponse createNewTeam(MemberDto member, String teamName);
+    TeamDto findTeam(String teamName);
+    ApplicationJoinTeamDto findApplication(String teamName, String memberId);
+    void applyToTeam(String teamName, String memberId, String message);
+    AcceptApplicationResponse acceptApplication(String teamName, String memberId);
     AuthorityType authorityCheck(String teamName, String memberId);
     void withdrawal(String teamName, String memberId);
-    void disbandmentTeam(Team team);
-    List<TeamMember> findTeamMember(String teamName, String memberId);
-    void updateAuthority(TeamMember member, AuthorityType authorityType);
+    DisbandmentTeamResponse disbandmentTeam(String teamName);
+    List<TeamMemberDto> findTeamMember(String teamName, String memberId);
+    UpdateAuthorityResponse updateAuthority(String teamName, String memberId, AuthorityType authorityType);
 }

--- a/football_love/src/main/java/com/deu/football_love/service/TeamServiceImpl.java
+++ b/football_love/src/main/java/com/deu/football_love/service/TeamServiceImpl.java
@@ -2,50 +2,96 @@ package com.deu.football_love.service;
 
 import com.deu.football_love.domain.*;
 import com.deu.football_love.domain.type.AuthorityType;
-import com.deu.football_love.dto.TeamDto;
+import com.deu.football_love.dto.*;
+import com.deu.football_love.repository.MemberRepository;
 import com.deu.football_love.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
-@Transactional
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class TeamServiceImpl implements TeamService{
 
     private final TeamRepository teamRepository;
+    private final MemberRepository memberRepository;
 
-    public TeamDto getTeamInfo(Team team)
+    @Transactional(readOnly = true)
+    public TeamDto getTeamInfo(String teamName)
     {
+        Team team = teamRepository.selectTeam(teamName);
+        if (team == null)
+            return null;
         return TeamDto.from(team);
     }
 
     @Override
-    public void createNewTeam(Team team) {
+    @Transactional(readOnly = false)
+    public CreateTeamResponse createNewTeam(MemberDto member, String teamName) {
+        Team team = new Team();
+        Member findMember = memberRepository.selectMember(member.getId());
+        if (findMember == null)
+            return null;
+        TeamMember teamMember = new TeamMember(team, findMember, AuthorityType.LEADER);
+        team.setName(teamName);
+        team.setCreateDate(LocalDate.now());
+        teamMember.setTeam(team);
+        teamMember.setMember(findMember);
+        team.getTeamMembers().add(teamMember);
         teamRepository.insertTeam(team);
+        teamRepository.insertNewTeamMember(teamMember);
+        return new CreateTeamResponse(teamName);
     }
 
     @Override
-    public Team findTeam(String teamName)
+    @Transactional(readOnly = true)
+    public TeamDto findTeam(String teamName)
     {
-        return teamRepository.selectTeam(teamName);
+        Team team = teamRepository.selectTeam(teamName);
+        if (team == null)
+            return null;
+        return TeamDto.from(team);
     }
 
     @Override
-    public ApplicationJoinTeam findApplication(String teamName, String memberId) {
-        return teamRepository.selectApplication(teamName, memberId);
+    @Transactional(readOnly = true)
+    public ApplicationJoinTeamDto findApplication(String teamName, String memberId) {
+        ApplicationJoinTeam application = teamRepository.selectApplication(teamName, memberId);
+        if (application == null)
+            return null;
+        return new ApplicationJoinTeamDto(application);
     }
+
     @Override
-    public void applyToTeam(ApplicationJoinTeam application) {
+    @Transactional(readOnly = false)
+    public void applyToTeam(String teamName, String memberId, String message) {
+
+        Team findTeam = teamRepository.selectTeam(teamName);
+        Member findMember = memberRepository.selectMember(memberId);
+        ApplicationJoinTeam application = new ApplicationJoinTeam(findTeam, findMember, message);
+        findTeam.getApplicationJoinTeams().add(application);
         teamRepository.insertNewApplication(application);
     }
 
     @Override
-    public void acceptApplication(ApplicationJoinTeam application, TeamMember newTeamMember) {
-        teamRepository.deleteApplication(application);
+    @Transactional(readOnly = false)
+    public AcceptApplicationResponse acceptApplication(String teamName, String memberId) {
+        ApplicationJoinTeam findApplication = teamRepository.selectApplication(teamName, memberId);
+        Team findTeam = teamRepository.selectTeam(teamName);
+        Member findMember = memberRepository.selectMember(memberId);
+        if (findApplication == null || findTeam == null || findMember == null)
+            return null;
+        teamRepository.deleteApplication(findApplication);
+        TeamMember newTeamMember = new TeamMember(findTeam, findMember, AuthorityType.MEMBER);
+        findTeam.getTeamMembers().add(newTeamMember);
         teamRepository.insertNewTeamMember(newTeamMember);
+        return new AcceptApplicationResponse(teamName, memberId);
     }
 
     /**
@@ -53,6 +99,7 @@ public class TeamServiceImpl implements TeamService{
      * 
      */
     @Override
+    @Transactional(readOnly = true)
     public AuthorityType authorityCheck(String teamName, String memberId)
     {
         List<TeamMember> teamMembers = teamRepository.selectTeamMember(teamName, memberId);
@@ -63,26 +110,45 @@ public class TeamServiceImpl implements TeamService{
     }
 
     @Override
-    public List<TeamMember> findTeamMember(String teamName, String memberId)
+    @Transactional(readOnly = true)
+    public List<TeamMemberDto> findTeamMember(String teamName, String memberId)
     {
-        return teamRepository.selectTeamMember(teamName, memberId);
+        List<TeamMember> teamMembers = teamRepository.selectTeamMember(teamName, memberId);
+        List<TeamMemberDto> collect = teamMembers.stream().map(tm -> new TeamMemberDto(tm))
+                .collect(Collectors.toList());
+        return collect;
     }
+
     @Override
+    @Transactional(readOnly = false)
     public void withdrawal(String teamName, String memberId)
     {
-        teamRepository.deleteTeamMember(teamName, memberId);
+        List<TeamMember> teamMembers = teamRepository.selectTeamMember(teamName, memberId);
+        if(teamMembers.size() != 0) {
+            teamRepository.deleteTeamMember(teamName, memberId);
+        }
     }
 
     @Override
-    public void disbandmentTeam(Team team)
+    @Transactional(readOnly = false)
+    public DisbandmentTeamResponse disbandmentTeam(String teamName)
     {
+        Team team = teamRepository.selectTeam(teamName);
+        if (team == null)
+            return null;
         teamRepository.deleteTeam(team);
+        return new DisbandmentTeamResponse(teamName);
     }
 
     @Override
-    public void updateAuthority(TeamMember member, AuthorityType authorityType)
+    @Transactional(readOnly = false)
+    public UpdateAuthorityResponse updateAuthority(String teamName, String memberId, AuthorityType authorityType)
     {
-        member.setAuthority(authorityType);
+        List<TeamMember> teamMembers = teamRepository.selectTeamMember(teamName, memberId);
+        if (teamMembers.size() == 0)
+            return null;
+        teamMembers.get(0).setAuthority(authorityType);
+        return new UpdateAuthorityResponse(teamName, memberId, authorityType);
     }
 
 }

--- a/football_love/src/test/java/com/deu/football_love/membertest/MemberTest.java
+++ b/football_love/src/test/java/com/deu/football_love/membertest/MemberTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.deu.football_love.domain.Member;
+import com.deu.football_love.dto.MemberDto;
 import com.deu.football_love.service.MemberService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,7 +47,8 @@ public class MemberTest {
 		member.setName("jinhpark");
 		String encodePassword = passwordEncoder.encode("1234");
 		member.setPwd(encodePassword);
-		memberService.join(member);
+		MemberDto memberDto = new MemberDto(member);
+		memberService.join(memberDto);
 		assertEquals(member, memberService.findMember("pjh612"));
 	}
 }


### PR DESCRIPTION
# 📙 작업 내역

구현 내용 및 작업 했던 내역

2021-11-15
- Service에서 Controller 간의 데이터를 DTO로 주고받기 때문에 team, post 부분 수정
- DTO 사용에 따른 테스트 코드 수정
- MemberDTO에서 탈퇴 정보의 null 예외처리가 안되어있어 임시 수정
- cascade 옵션 수정
- 그 외 refactoring

2021-11-16
- Match, Stadium, Company DTO 작성
- Match, Stadium, Company의 Controller, Repository, Service 작성 (미완성)
- reservation_time을 reservationTime으로 명명
# 작업 유형

- [x] 신규 기능 추가
- [x] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

# 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

# 📝 PR 특이 사항

PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 아직 Match, Stadium, Company의 service, repository의 인터페이스는 작성하지 않았습니다. 차후 분리해야 함.
- CreateMatchResponse와 MatchDto , AddCompanyResponse와 CompanyDto, AddStadiumResponse와 StadiumDto의 구조가 동일하게 작성되었습니다. CreateXX, AddXX 같은 경우는 추가를 할때 응답으로 primary key인 id를 포함해서 추가된 데이터의 정보를 반환하는 DTO이고, XXDto는 조회할 때 데이터를 반환하는 DTO입니다.
현재는 구조가 같지만 차후에는 어떻게 달라질지 모르기 때문에 분리 해놨습니다.
