### PR TITLE
2021-12-23 수정사항 (탈퇴 Cascade, 테스트 코드, 연관관계 등)

### DIFF
--- a/football_love/src/main/java/com/deu/football_love/controller/CompanyController.java
+++ b/football_love/src/main/java/com/deu/football_love/controller/CompanyController.java
@@ -9,11 +9,7 @@ import com.deu.football_love.service.CompanyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/company")
@@ -22,14 +18,14 @@ public class CompanyController {
     private final CompanyService companyService;
 
     @PostMapping
-    public ResponseEntity add(AddCompanyRequest request)
+    public ResponseEntity add(@RequestBody AddCompanyRequest request)
     {
         AddCompanyResponse response = companyService.addCompany(request.getCompanyName(), request.getOwnerNumber(), request.getLocation(), request.getTel(), request.getDescription());
         return new ResponseEntity(response, HttpStatus.OK);
     }
 
     @DeleteMapping
-    public ResponseEntity withdrawal(WithdrawalCompanyRequest request)
+    public ResponseEntity withdrawal(@RequestBody WithdrawalCompanyRequest request)
     {
         WithdrawalCompanyResponse response = companyService.withdrawalCompany(request.getCompanyId());
         return new ResponseEntity(response, HttpStatus.OK);

--- a/football_love/src/main/java/com/deu/football_love/domain/Address.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/Address.java
@@ -1,9 +1,12 @@
 package com.deu.football_love.domain;
 
-
+import lombok.Getter;
+import lombok.ToString;
 import javax.persistence.Embeddable;
 
 @Embeddable
+@ToString
+@Getter
 public class Address {
 
     private String city;

--- a/football_love/src/main/java/com/deu/football_love/domain/BaseTimeEntity.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/BaseTimeEntity.java
@@ -1,6 +1,7 @@
 package com.deu.football_love.domain;
 
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -11,6 +12,7 @@ import javax.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public class BaseTimeEntity {

--- a/football_love/src/main/java/com/deu/football_love/domain/Company.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/Company.java
@@ -29,7 +29,7 @@ public class Company extends BaseEntity {
     @Column(name = "company_description")
     private String description;
 
-    @OneToOne(cascade = CascadeType.REMOVE)
+    @OneToOne
     @JoinColumn(name = "owner_number", referencedColumnName = "member_number")
     private Member owner;
 
@@ -42,5 +42,11 @@ public class Company extends BaseEntity {
         this.location = location;
         this.tel = tel;
         this.description = description;
+    }
+
+    public void deleteCompany()
+    {
+        owner.setCompany(null);
+        this.owner = null;
     }
 }

--- a/football_love/src/main/java/com/deu/football_love/domain/Member.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/Member.java
@@ -67,7 +67,7 @@ public class Member extends BaseEntity {
     @OneToOne(mappedBy = "member", cascade = CascadeType.ALL)
     private WithdrawalMember withdrawalMember;
 
-    @OneToOne(mappedBy = "owner")
+    @OneToOne(mappedBy = "owner", orphanRemoval = true)
     private Company company;
 
 

--- a/football_love/src/main/java/com/deu/football_love/domain/WithdrawalMember.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/WithdrawalMember.java
@@ -9,12 +9,13 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class WithdrawalMember extends BaseEntity {
 
     @Id
@@ -26,6 +27,7 @@ public class WithdrawalMember extends BaseEntity {
     @JoinColumn(name = "member_number", referencedColumnName = "member_number")
     private Member member;
 
-    @Column(name = "withdrawal_date")
-    private LocalDateTime date;
+    public WithdrawalMember(Member member) {
+        this.member = member;
+    }
 }

--- a/football_love/src/main/java/com/deu/football_love/dto/company/AddCompanyRequest.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/company/AddCompanyRequest.java
@@ -1,28 +1,26 @@
 package com.deu.football_love.dto.company;
 
 import com.deu.football_love.domain.Address;
-import com.deu.football_love.domain.Company;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AddCompanyRequest {
-    private Long companyId;
     private String companyName;
     private Long ownerNumber;
     private Address location;
     private String tel;
     private String description;
 
-    public AddCompanyRequest(Long id, String name, Long ownerNumber, Address location, String tel, String description) {
-        this.companyId = id;
+    public AddCompanyRequest(String name, Long ownerNumber, Address location, String tel, String description) {
         this.companyName = name;
         this.ownerNumber = ownerNumber;
         this.location = location;
         this.tel = tel;
         this.description = description;
-    }
-
-    public static AddCompanyResponse from(Company company) {
-        return new AddCompanyResponse(company.getId(), company.getName(), company.getOwner().getNumber(), company.getLocation(), company.getTel(), company.getDescription());
     }
 }

--- a/football_love/src/main/java/com/deu/football_love/dto/company/AddCompanyResponse.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/company/AddCompanyResponse.java
@@ -8,15 +8,15 @@ import lombok.Getter;
 public class AddCompanyResponse {
     private Long companyId;
     private String companyName;
-    private Long owner;
+    private Long ownerNumber;
     private Address location;
     private String tel;
     private String description;
 
-    public AddCompanyResponse(Long id, String name, Long owner, Address location, String tel, String description) {
+    public AddCompanyResponse(Long id, String name, Long ownerNumber, Address location, String tel, String description) {
         this.companyId = id;
         this.companyName = name;
-        this.owner = owner;
+        this.ownerNumber = ownerNumber;
         this.location = location;
         this.tel = tel;
         this.description = description;

--- a/football_love/src/main/java/com/deu/football_love/dto/member/QueryMemberDto.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/member/QueryMemberDto.java
@@ -8,13 +8,9 @@ import com.deu.football_love.domain.type.MemberType;
 import com.deu.football_love.domain.type.TeamMemberType;
 import com.deu.football_love.dto.company.QueryCompanyDto;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import org.apache.tomcat.jni.Local;
-
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -61,6 +57,10 @@ public class QueryMemberDto extends BaseEntity {
 		this.teams = member.getTeamMembers().stream().map(tm -> new TeamDto(tm.getTeam().getId(), tm.getTeam().getName(), tm.getType())).collect(Collectors.toList());
 		if (member.getCompany() != null)
 		this.company = QueryCompanyDto.from(member.getCompany());
+		setCreatedBy(member.getCreatedBy());
+		setLastModifiedBy(member.getLastModifiedBy());
+		setCreatedDate(member.getCreatedDate());
+		setLastModifiedDate(member.getLastModifiedDate());
 	}
 
 	class TeamDto

--- a/football_love/src/main/java/com/deu/football_love/dto/team/CreateTeamRequest.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/team/CreateTeamRequest.java
@@ -1,8 +1,15 @@
 package com.deu.football_love.dto.team;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CreateTeamRequest {
     private String name;
+
+    public CreateTeamRequest(String name) {
+        this.name = name;
+    }
 }

--- a/football_love/src/main/java/com/deu/football_love/repository/MemberRepository.java
+++ b/football_love/src/main/java/com/deu/football_love/repository/MemberRepository.java
@@ -22,7 +22,7 @@ public interface MemberRepository {
 
     //Member updateMember(JoinRequest joinRequest);
 
-    void updateWithdraw(String memberId);
+    void updateWithdraw(Member member);
 
     Long chkWithDraw(String id);
 

--- a/football_love/src/main/java/com/deu/football_love/repository/MemberRepositoryImpl.java
+++ b/football_love/src/main/java/com/deu/football_love/repository/MemberRepositoryImpl.java
@@ -69,10 +69,8 @@ public class MemberRepositoryImpl implements MemberRepository {
 	}
 
 	@Override
-	public void updateWithdraw(String memberId) {
-		List<Member> findMember = em.createQuery("SELECT m FROM Member m where m.id = :id", Member.class).setParameter("id", memberId).getResultList();
-		WithdrawalMember state = new WithdrawalMember();
-		state.setMember(findMember.get(0));
+	public void updateWithdraw(Member member) {
+		WithdrawalMember state = new WithdrawalMember(member);
 		em.persist(state);
 	}
 

--- a/football_love/src/main/java/com/deu/football_love/service/CompanyServiceImpl.java
+++ b/football_love/src/main/java/com/deu/football_love/service/CompanyServiceImpl.java
@@ -48,7 +48,7 @@ public class CompanyServiceImpl implements CompanyService {
     public AddCompanyResponse addCompany(String name, Long ownerNumber, Address location, String tel, String description) {
         Member findMember = memberRepository.selectMember(ownerNumber);
         Company newCompany = companyRepository.insertCompany(new Company(name, findMember, location, tel, description));
-        log.info("companyId ={}", newCompany.getId());
+        findMember.setCompany(newCompany);
         return AddCompanyResponse.from(newCompany);
     }
 

--- a/football_love/src/main/java/com/deu/football_love/service/PostService.java
+++ b/football_love/src/main/java/com/deu/football_love/service/PostService.java
@@ -2,6 +2,8 @@ package com.deu.football_love.service;
 
 import com.deu.football_love.dto.post.*;
 
+import java.util.List;
+
 public interface PostService {
     WritePostResponse writePost(WritePostRequest request);
 
@@ -10,4 +12,6 @@ public interface PostService {
     ModifyPostResponse modifyPost(Long postId, UpdatePostRequest request);
 
     QueryPostDto findPost(Long postId);
+
+    List<QueryPostDto> findAllPostsByBoardId(Long boardId);
 }

--- a/football_love/src/main/java/com/deu/football_love/service/PostServiceImpl.java
+++ b/football_love/src/main/java/com/deu/football_love/service/PostServiceImpl.java
@@ -69,6 +69,7 @@ public class PostServiceImpl implements PostService {
         return QueryPostDto.from(post);
     }
 
+    @Override
     public List<QueryPostDto> findAllPostsByBoardId(Long boardId)
     {
         List<Post> posts = postRepository.selectAllPostsByBoardId(boardId);

--- a/football_love/src/main/java/com/deu/football_love/service/TeamServiceImpl.java
+++ b/football_love/src/main/java/com/deu/football_love/service/TeamServiceImpl.java
@@ -174,8 +174,7 @@ public class TeamServiceImpl implements TeamService {
         while (team.getTeamMembers().size() != 0) {
             TeamMember teamMember = team.getTeamMembers().get(0);
             Long teamMemberId = teamMember.getId();
-            teamMember.setTeam(null);
-            team.getTeamMembers().remove(teamMember);
+            teamMember.deleteTeamMember();;
             teamRepository.deleteTeamMember(team.getId(), teamMemberId);
         }
         teamRepository.deleteTeam(team);

--- a/football_love/src/test/java/com/deu/football_love/controller/MemberControllerTest.java
+++ b/football_love/src/test/java/com/deu/football_love/controller/MemberControllerTest.java
@@ -1,0 +1,120 @@
+package com.deu.football_love.controller;
+
+import com.deu.football_love.domain.Address;
+import com.deu.football_love.domain.type.MemberType;
+import com.deu.football_love.dto.auth.LoginRequest;
+import com.deu.football_love.dto.member.MemberJoinRequest;
+import com.deu.football_love.dto.member.QueryMemberDto;
+import com.deu.football_love.dto.team.CreateTeamRequest;
+import com.deu.football_love.dto.team.QueryTeamDto;
+import com.deu.football_love.repository.MemberRepository;
+import com.deu.football_love.service.MemberService;
+import com.deu.football_love.service.TeamService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class MemberControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    MemberService memberService;
+
+    @Autowired
+    TeamService teamService;
+
+    @Autowired
+    UserDetailsService userDetailsService;
+
+    ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    @Test
+    public void join() throws Exception {
+        Address address = new Address("busan", "guemgangro", "46233");
+        MemberJoinRequest request = new MemberJoinRequest("pjh612","123","jhjh","박진형",
+               null, address, "pjh_jn@naver.com","01021042419", MemberType.NORMAL);
+
+        mvc.perform(MockMvcRequestBuilders.post("/member")
+                .contentType("application/json")
+                .content(mapper.writeValueAsString(request))
+        ).andExpect(status().isOk())
+                .andExpect(jsonPath("$.id",is(request.getId())))
+                .andExpect( jsonPath("$.name",is(request.getName())))
+                .andExpect( jsonPath("$.nickname",is(request.getNickname())))
+                .andExpect( jsonPath("$.address.city",is(request.getAddress().getCity())))
+                .andExpect( jsonPath("$.address.street",is(request.getAddress().getStreet())))
+                .andExpect( jsonPath("$.address.zipcode",is(request.getAddress().getZipcode())))
+                .andExpect( jsonPath("$.birth",is(request.getBirth())))
+                .andExpect( jsonPath("$.email",is(request.getEmail())))
+                .andExpect( jsonPath("$.phone",is(request.getPhone())))
+                .andExpect( jsonPath("$.type",is(request.getType().toString())))
+                .andDo(print());
+    }
+
+    @Test
+    public void login() throws Exception {
+        Address address = new Address("busan", "guemgangro", "46233");
+        mapper.registerModule(new JavaTimeModule());
+        MemberJoinRequest request = new MemberJoinRequest("pjh612","123","jhjh","박진형",
+                null, address, "pjh_jn@naver.com","01021042419", MemberType.NORMAL);
+
+        LoginRequest loginRequest = new LoginRequest(request.getId(), request.getPwd());
+        memberService.join(request);
+
+        mvc.perform(MockMvcRequestBuilders.post("/member/login_jwt/"+ request.getId())
+                .contentType("application/json")
+                .content(mapper.writeValueAsString(loginRequest))
+        ).andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    public void createTeam() throws Exception {
+
+        Address address = new Address("busan", "guemgangro", "46233");
+        mapper.registerModule(new JavaTimeModule());
+        MemberJoinRequest request = new MemberJoinRequest("pjh612","123","jhjh","박진형",
+                null, address, "pjh_jn@naver.com","01021042419", MemberType.NORMAL);
+        QueryMemberDto join = memberService.join(request);
+        CreateTeamRequest createTeamRequest = new CreateTeamRequest("FC진형");
+        UserDetails userDetails = userDetailsService.loadUserByUsername(join.getId());
+        mvc.perform(MockMvcRequestBuilders.post("/team").with(user(userDetails))
+                .contentType("application/json")
+                .content(mapper.writeValueAsString(createTeamRequest))
+        ).andExpect(status().isOk())
+                .andDo(print());
+
+        QueryTeamDto findTeam = teamService.findTeamByName(createTeamRequest.getName());
+        QueryMemberDto memberA = memberService.findMemberById("pjh612");
+        assertNotNull(findTeam);
+        assertEquals(1, teamService.findTeamMember(findTeam.getId(), memberA.getNumber()).size());
+    }
+
+   /* @Test
+    public void */
+
+}

--- a/football_love/src/test/java/com/deu/football_love/member/MemberTest.java
+++ b/football_love/src/test/java/com/deu/football_love/member/MemberTest.java
@@ -33,7 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional
 @Slf4j
 @RequiredArgsConstructor
-@ExtendWith(MockitoExtension.class)
+
 public class MemberTest {
 
 	@Autowired

--- a/football_love/src/test/java/com/deu/football_love/service/CompanyServiceTest.java
+++ b/football_love/src/test/java/com/deu/football_love/service/CompanyServiceTest.java
@@ -67,6 +67,7 @@ class CompanyServiceTest {
     }
 
     @Test
+    //@Rollback(value = false)
     public void withdrawalCascadeTest()
     {
         MemberJoinRequest memberADto = new MemberJoinRequest("memberA", passwordEncoder.encode("1234"), "jinhyungPark", "jinhyungPark", LocalDate.now(), new Address("busan", "guemgangro", "46233"), "pjh_jn@naver.com", "01012341234", MemberType.BUSINESS);
@@ -74,8 +75,6 @@ class CompanyServiceTest {
         AddCompanyResponse newCompany = companyService.addCompany("companyA", memberA.getNumber(), new Address("busan", "geumgangro", "46233"), "01012341234", "부산 금강로에 위치한 풋살장");
 
         memberService.withdraw("memberA");
-        QueryMemberDto findMember = memberService.findMember(memberA.getNumber());
-        em.remove(memberRepository.selectMember(findMember.getNumber()));
         Assertions.assertEquals(1, memberRepository.chkWithDraw("memberA"));
         Assertions.assertNull(companyService.findCompany(newCompany.getCompanyId()));
     }

--- a/football_love/src/test/java/com/deu/football_love/service/PostServiceTest.java
+++ b/football_love/src/test/java/com/deu/football_love/service/PostServiceTest.java
@@ -154,6 +154,7 @@ public class PostServiceTest {
     @Test
     public void cascadeMemberTest()
     {
+        //given
         MemberJoinRequest memberADto = new MemberJoinRequest("memberA", passwordEncoder.encode("1234"), "jinhyungPark", "jinhyungPark", LocalDate.now(), new Address("busan", "guemgangro", "46233"), "pjh_jn@naver.com", "01012341234", MemberType.NORMAL);
         QueryMemberDto memberJoinResponse = memberService.join(memberADto);
         CreateTeamResponse teamA = teamService.createNewTeam(memberADto.getId(), "teamA");
@@ -173,22 +174,11 @@ public class PostServiceTest {
         WritePostResponse writePostResponse4 = postService.writePost(writePostRequest4);
 
         Member findMember = memberRepository.selectMemberById("memberA");
-        memberService.withdraw(findMember.getId());
-        while (findMember.getPosts().size() != 0)
-        {
-            Post curPost = findMember.getPosts().get(0);
-            curPost.deletePost();
-            postRepository.deletePost(curPost);
-        }
-        List<TeamMember> teamMembers = findMember.getTeamMembers();
-        while (teamMembers.size() != 0) {
-            TeamMember curTeamMember = teamMembers.get(0);
-            curTeamMember.deleteTeamMember();
-            teamRepository.deleteTeamMember(curTeamMember.getTeam().getId(), curTeamMember.getMember().getNumber());
-        }
-        memberRepository.deleteMember(memberRepository.selectMemberById("memberA"));
 
-        Assertions.assertNull(memberRepository.selectMemberById("memberA"));
+        //when
+        memberService.withdraw(findMember.getId());
+
+        //then
         Assertions.assertNull(postRepository.selectPost(writePostResponse1.getPostId()));
         Assertions.assertNull(postRepository.selectPost(writePostResponse2.getPostId()));
         Assertions.assertNull(postRepository.selectPost(writePostResponse3.getPostId()));

--- a/football_love/src/test/java/com/deu/football_love/service/TeamServiceImplTest.java
+++ b/football_love/src/test/java/com/deu/football_love/service/TeamServiceImplTest.java
@@ -130,15 +130,22 @@ public class TeamServiceImplTest {
         long teamId = findTeam.getId();
         teamService.applyToTeam(findTeam.getId(), "memberB", "hi");
         teamService.acceptApplication(findTeam.getId(), "memberB");
+
+        QueryMemberDto memberA = memberService.findMemberById("memberA");
+        QueryMemberDto memberB = memberService.findMemberById("memberB");
+        AddBoardResponse boardA = boardService.add(new AddBoardRequest("boardA", BoardType.NOTICE, teamId));
+        postService.writePost(new WritePostRequest(memberA.getNumber(), boardA.getBoardId(), "hello", "content"));
+        postService.writePost(new WritePostRequest(memberB.getNumber(), boardA.getBoardId(), "hello", "content"));
         teamService.disbandmentTeam(findTeam.getId());
 
-    /*    MemberResponse memberA = memberService.findMemberById("memberA");
-        MemberResponse memberB = memberService.findMemberById("memberB");*/
-        /*     assertNull(teamRepository.selectTeam(findTeam.getId()));
-         *//*     assertEquals(teamRepository.selectTeamMember(teamId, memberA.getNumber()).size(), 0);
-        assertEquals(teamRepository.selectTeamMember(teamId, memberB.getNumber()).size(), 0);*//*
+
+        assertNull(teamRepository.selectTeam(findTeam.getId()));
+        assertEquals(0, teamRepository.selectTeamMember(teamId, memberA.getNumber()).size());
+        assertEquals(0, teamRepository.selectTeamMember(teamId, memberB.getNumber()).size());
+        assertNull(boardService.findById(boardA.getBoardId()));
+        assertEquals(0,postService.findAllPostsByBoardId(boardA.getBoardId()).size());
         assertNotNull(memberRepository.selectMemberById("memberA"));
-        assertNotNull(memberRepository.selectMemberById("memberB"));*/
+        assertNotNull(memberRepository.selectMemberById("memberB"));
     }
 
     @Test


### PR DESCRIPTION
# 📙 작업 내역

구현 내용 및 작업 했던 내역

- BaseTimeEntity에 setter 추가
- QueryMemberDto에 BaseDto 관련 내용 들어가지 않던 것 수정
- CreateTeamRequest 생성자 추가
- CompanyController에 RequestBody 애노테이션 추가
- AddressEntity에 ToString과 Getter추가
- AddCompanyResponse의 owner -> ownerNumber
- Company 삭제 편의 메소드 추가
- addCompany 시 양방향 연관관계가 제대로 맺어지지 않는부분 수정
- Member 탈퇴
  - Member Entity의 company에 orphanRemoval을 추가해서 Member 탈퇴 시 Company 정보 삭제 되도록 변경
  - Member 탈퇴 시 소속 팀, 소유 팀 모두 삭제 되도록 추가
- PostService 인터페이스에 findAllPostsByBoardId 없던 것 추가
- WithdrawalMember의 Setter 삭제, 생성자 추가(생성자 사용으로 안정성을 높임)
- 변경 사항에 따른 테스트 코드 수정
- 그 외 코드 정리
# 작업 유형

- [x] 신규 기능 추가
- [x] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

# 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

# 📝 PR 특이 사항

