### PR TITLE
[feat] 프로필이미지 Upload기능 추가 등

### DIFF
--- a/football_love/build.gradle
+++ b/football_love/build.gradle
@@ -39,6 +39,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	implementation 'org.springframework.boot:spring-boot-starter-quartz'
 	testImplementation 'org.springframework.batch:spring-batch-test'
+	implementation platform("com.google.cloud:spring-cloud-gcp-dependencies:2.0.7")
+	implementation("com.google.cloud:spring-cloud-gcp-starter-storage")
+
+	implementation platform('com.google.cloud:libraries-bom:24.2.0')
+	implementation 'com.google.cloud:google-cloud-storage'
+
 }
 
 test {

--- a/football_love/src/main/java/com/deu/football_love/config/WebSecurityConfig.java
+++ b/football_love/src/main/java/com/deu/football_love/config/WebSecurityConfig.java
@@ -8,7 +8,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -38,15 +37,23 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
 
+		configuration.addAllowedOrigin("http://115.85.183.128:3000");
 		configuration.addAllowedOrigin("http://127.0.0.1:3000");
+		configuration.addAllowedOrigin("http://localhost:3000");
+		configuration.addAllowedOrigin("https://127.0.0.1:3000");
+		configuration.addAllowedOrigin("https://localhost:3000");
+		configuration.addAllowedOrigin("https://dev.example.com:3000");
+		configuration.addAllowedOrigin("https://localhost:3000");
+		configuration.addAllowedOrigin("https://flove.fbl.p-e.kr");
 		configuration.addAllowedHeader("*");
 		configuration.addAllowedMethod("*");
 		configuration.setAllowCredentials(true);
-
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
 		source.registerCorsConfiguration("/**", configuration);
 		return source;
 	}
+
+
 
 	@Override
 	protected void configure(HttpSecurity http) throws Exception{
@@ -59,7 +66,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 					.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 				.and()
 					.authorizeRequests()
-					.antMatchers("/member","/member/login_jwt/**","/member/login/**","/member/**","/team/**").permitAll()
+					.antMatchers("/**", "/","/member","/member/login_jwt/**","/team/**").permitAll()
 					.anyRequest().authenticated()
 				.and()
 					.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);

--- a/football_love/src/main/java/com/deu/football_love/controller/StorageController.java
+++ b/football_love/src/main/java/com/deu/football_love/controller/StorageController.java
@@ -1,0 +1,38 @@
+package com.deu.football_love.controller;
+
+import com.deu.football_love.dto.auth.LoginInfo;
+import com.deu.football_love.dto.cloud_storage.UploadImageRequest;
+import com.deu.football_love.service.GcpStorageService;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+public class StorageController {
+
+    private final GcpStorageService gcpStorageService;
+
+
+    @SneakyThrows
+    @PostMapping(value = "/api/upload")
+    public String upload(UploadImageRequest request, @AuthenticationPrincipal LoginInfo loginInfo) {
+        log.info("id = {}", loginInfo.getId());
+        String imgUri = gcpStorageService.updateProfileImg(request.getFile(), loginInfo.getId());
+        return imgUri;
+    }
+
+
+    @GetMapping(value = "/api/upload")
+    public String get(UploadImageRequest request) {
+       return "mapping test";
+
+    }
+
+}

--- a/football_love/src/main/java/com/deu/football_love/controller/consts/SessionConst.java
+++ b/football_love/src/main/java/com/deu/football_love/controller/consts/SessionConst.java
@@ -1,5 +1,0 @@
-package com.deu.football_love.controller.consts;
-
-public class SessionConst {
-    public static final String SESSION_MEMBER = "memberInfo";
-}

--- a/football_love/src/main/java/com/deu/football_love/domain/Member.java
+++ b/football_love/src/main/java/com/deu/football_love/domain/Member.java
@@ -1,16 +1,13 @@
 package com.deu.football_love.domain;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.persistence.*;
-
 import com.deu.football_love.domain.type.MemberType;
 import com.deu.football_love.dto.member.UpdateMemberRequest;
-
 import lombok.*;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -51,6 +48,9 @@ public class Member extends BaseEntity {
 
     @Column(name = "member_type")
     private MemberType memberType;
+
+    @Column(name = "member_profile_img_uri")
+    private String profileImgUri;
 
     @OneToMany(mappedBy = "author")
     private List<Post> posts = new ArrayList<>();
@@ -93,5 +93,9 @@ public class Member extends BaseEntity {
         birth = request.getBirth();
         address = request.getAddress();
         phone = request.getPhone();
+    }
+
+    public void updateProfileImgUri(String uri) {
+        profileImgUri = uri;
     }
 }

--- a/football_love/src/main/java/com/deu/football_love/dto/auth/LoginInfo.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/auth/LoginInfo.java
@@ -3,6 +3,7 @@ package com.deu.football_love.dto.auth;
 import com.deu.football_love.domain.Member;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -12,6 +13,7 @@ import java.util.Collection;
 
 @Getter
 @ToString
+@Slf4j
 public class LoginInfo implements UserDetails {
     private Long number;
     private String id;
@@ -20,6 +22,7 @@ public class LoginInfo implements UserDetails {
     private Collection<GrantedAuthority> roles;
 
     public LoginInfo() {
+        this.number= -1L;
         this.number = -1L;
         this.name = "anonymous";
         this.password = "secret";

--- a/football_love/src/main/java/com/deu/football_love/dto/cloud_storage/UploadImageRequest.java
+++ b/football_love/src/main/java/com/deu/football_love/dto/cloud_storage/UploadImageRequest.java
@@ -1,0 +1,17 @@
+package com.deu.football_love.dto.cloud_storage;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UploadImageRequest {
+    private MultipartFile file;
+
+    public UploadImageRequest(MultipartFile file) {
+        this.file = file;
+    }
+}

--- a/football_love/src/main/java/com/deu/football_love/service/GcpStorageService.java
+++ b/football_love/src/main/java/com/deu/football_love/service/GcpStorageService.java
@@ -1,0 +1,60 @@
+package com.deu.football_love.service;
+
+import com.deu.football_love.domain.Member;
+import com.deu.football_love.repository.MemberRepository;
+import com.google.cloud.WriteChannel;
+import com.google.cloud.storage.Acl;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.common.io.ByteStreams;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.Channels;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class GcpStorageService {
+
+    private final Storage storage;
+
+    @Value("${spring.cloud.gcp.storage.profileBucketName}")
+    private String profileBucketName;
+
+    private final MemberRepository memberRepository;
+
+    public String updateProfileImg(MultipartFile file, String userId) throws IOException {
+        InputStream targetStream = new ByteArrayInputStream(file.getBytes());
+        Member findMember = memberRepository.selectMemberById(userId);
+        String imgName;
+        if (findMember.getProfileImgUri() != null)
+            imgName = findMember.getProfileImgUri();
+        else
+            imgName = userId + UUID.randomUUID();
+        BlobInfo blobInfo = BlobInfo.newBuilder(profileBucketName, imgName)
+                .setContentType(file.getContentType())
+                .setAcl(new ArrayList<>(Arrays.asList(Acl.of(Acl.User.ofAllUsers(), Acl.Role.READER))))
+                .build();
+        try (WriteChannel writer = storage.writer(blobInfo, Storage.BlobWriteOption.md5Match())) {
+            ByteStreams.copy(targetStream, Channels.newOutputStream(writer));
+
+        }
+        findMember.updateProfileImgUri(imgName);
+        return findMember.getProfileImgUri();
+    }
+
+
+
+}


### PR DESCRIPTION
# 📙 작업 내역

구현 내용 및 작업 했던 내역

- 프로필 사진 upload api 작성
  - /api/upload
  - key : "file" , value : file
  - 업로드된 파일 이름을 return 합니다.
- gcp 관련 의존성 추가
- session const 사용하지 않으므로 삭제
- LoginInfo의 memberNumber 기본값 넣어줬습니다.

# 작업 유형

- [x] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

# 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

# 📝 PR 특이 사항

Google클라우드 사용 관련 yml 설정과 인증서 파일은 저에게 따로 받으셔야합니다.
