### PR TITLE
add admin page

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -11,11 +11,11 @@ import Write from './components/Board/WritePage';
 import MyPage from './components/MyPage/MyPage';
 import TeamList from './components/TeamListPage/TeamList';
 import BoardPage from './components/TeamPage/TeamBoardPage';
-
+import AdminPage from './components/Admin/AdminPage';
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { updateUserAction, updateTeamAction } from './action/createAction';
-
+import { useUser } from './hooks/useUser';
 import { getUserInfo, getTeamInfo } from './axios/axios';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
@@ -30,6 +30,7 @@ function App() {
       },
     },
   });
+  const user = useUser();
 
   useEffect(() => {
     async function refresh() {
@@ -67,6 +68,7 @@ function App() {
             <Route path="/teams/:id/:boardNumber/write" element={<Write></Write>}></Route>
             <Route path="/teams/:id" element={<TeamPage></TeamPage>}></Route>
             <Route path="/teams/:id/:boardNumber" element={<TeamBoardPage></TeamBoardPage>}></Route>
+            <Route path="/admin" element={<AdminPage user={user}></AdminPage>}></Route>
           </Routes>
         </ThemeProvider>
       </BrowserRouter>

--- a/front/src/axios/axios.js
+++ b/front/src/axios/axios.js
@@ -95,3 +95,11 @@ export function getTeamBoardPosts(boardId) {
     url: `https://flove.fbl.p-e.kr/api/board/${boardId}/post`,
   });
 }
+
+export function makeBoardAdmin(data) {
+  return axios({
+    method: 'post',
+    url: 'https://flove.fbl.p-e.kr/api/board',
+    data: data,
+  });
+}

--- a/front/src/components/Admin/AdminPage.tsx
+++ b/front/src/components/Admin/AdminPage.tsx
@@ -1,0 +1,24 @@
+import { useUser } from '../../hooks/useUser';
+import BoardList from './BoardList';
+import BoardNameInput from './BoardNameInput';
+import CategoryName from './CategoryName';
+import SelectBox from './SelectBox';
+import Button from './Button';
+export default function AdminPage({ user }) {
+  // if (user.type !== 'ROLE_ADMIN') {
+  //   return <h1>This page is accessable only admin.</h1>;
+  // }
+  const selectList = ['NOTICE', 'PHOTO', 'GENERAL'];
+  return (
+    <>
+      <CategoryName category={'보드 생성'}></CategoryName>
+      <p>
+        <SelectBox selectList={selectList}></SelectBox>
+        <BoardNameInput></BoardNameInput>
+        <Button text={'생성하기'}></Button>
+      </p>
+      <CategoryName category={'보드 리스트'}></CategoryName>
+      <BoardList></BoardList>
+    </>
+  );
+}

--- a/front/src/components/Admin/BoardList.tsx
+++ b/front/src/components/Admin/BoardList.tsx
@@ -1,0 +1,17 @@
+import Button from './Button';
+
+export default function BoardList() {
+  return (
+    <ul>
+      <li>
+        첫번째 보드<Button text="Delete"></Button>
+      </li>
+      <li>
+        첫번째 보드<Button text="Delete"></Button>
+      </li>
+      <li>
+        첫번째 보드<Button text="Delete"></Button>
+      </li>
+    </ul>
+  );
+}

--- a/front/src/components/Admin/BoardNameInput.tsx
+++ b/front/src/components/Admin/BoardNameInput.tsx
@@ -1,0 +1,7 @@
+export default function BoardNameInput() {
+  return (
+    <>
+      <input placeholder="typing boardName"></input>
+    </>
+  );
+}

--- a/front/src/components/Admin/Button.tsx
+++ b/front/src/components/Admin/Button.tsx
@@ -1,0 +1,3 @@
+export default function Button({ text }) {
+  return <button>{text}</button>;
+}

--- a/front/src/components/Admin/CategoryName.tsx
+++ b/front/src/components/Admin/CategoryName.tsx
@@ -1,0 +1,7 @@
+export default function CategoryName({ category }) {
+  return (
+    <p>
+      <h2>{category}</h2>
+    </p>
+  );
+}

--- a/front/src/components/Admin/SelectBox.tsx
+++ b/front/src/components/Admin/SelectBox.tsx
@@ -1,0 +1,11 @@
+export default function SelectBox({ selectList }) {
+  return (
+    <select>
+      {selectList.map((item) => (
+        <option value={item} key={item}>
+          {item}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/front/src/components/Join/Join.tsx
+++ b/front/src/components/Join/Join.tsx
@@ -26,7 +26,7 @@ const Join = () => {
       birth: e.target.birth.value,
       email: e.target.email.value,
       phone: e.target.phone.value,
-      type: e.target.checkbox.checked ? 'ROLE_BUSINESS' : 'NORMAL',
+      type: e.target.checkbox.checked ? 'ROLE_BUSINESS' : 'ROLE_NORMAL',
     };
     console.log(e.target.checkbox.checked);
     console.log(data);

--- a/front/src/components/NavBar/MenuList.tsx
+++ b/front/src/components/NavBar/MenuList.tsx
@@ -73,6 +73,17 @@ export default function MenuList({ active, setActive }: any) {
           Sign in
         </button>
       )}
+      {user.type === 'ROLE_BUSINESS' ? (
+        <button
+          onClick={() => {
+            setActive(!active);
+            route('./addPlayground');
+          }}
+          className={styles.menu_button_style}
+        >
+          구장 등록
+        </button>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
# 📙 작업 내역

구현 내용 및 작업 했던 내역

- /admin is admin page.
- made static admin page ( I'll change it dynamic later )
- only "User-type : admin" can approach Admin page. 
- In adminPage, admin can create board category or delete.

# 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


